### PR TITLE
hooks: delay gdm.service until after snapd.seeded.services starts

### DIFF
--- a/hooks/006-add-gdm.chroot
+++ b/hooks/006-add-gdm.chroot
@@ -50,6 +50,7 @@ mv /etc/dbus-1/system.d/gdm.conf /usr/share/dbus-1/system.d/
 # Move display-manager.service symlink out of /etc
 rm /etc/systemd/system/display-manager.service
 ln -s gdm.service /lib/systemd/system/display-manager.service
+sed -i '/^Description=/ a # delay until snapd finishes seeding\nAfter=snapd.seeded.service' /lib/systemd/system/gdm.service
 
 # Remove D-Bus service activation files provided by
 # ubuntu-desktop-session snap.


### PR DESCRIPTION
At present, GDM starts up and displays gnome-initial-setup on the initial boot when Ubuntu Core is unpacking. This is an attempt to block that until the system has fully set up and is ready to use.