### PR TITLE
UCD-94: Add audio support for Core Desktop

### DIFF
--- a/hooks/000-provide-uids-gids.chroot
+++ b/hooks/000-provide-uids-gids.chroot
@@ -122,6 +122,7 @@ geoclue:x:111:120::/var/lib/geoclue:/bin/false
 gdm:x:112:121:Gnome Display Manager:/var/lib/gdm3:/bin/false
 colord:x:113:123:colord colour management daemon:/var/lib/colord:/usr/sbin/nologin
 gnome-initial-setup:x:114:65534::/run/gnome-initial-setup/:/bin/false
+rtkit:x:107:124:RealtimeKit,,,:/proc:/usr/sbin/nologin
 EOF
 cp /etc/passwd /etc/passwd.orig # We make a copy for a later sanity-compare
 
@@ -160,6 +161,7 @@ geoclue:*:18459:0:99999:7:::
 gdm:*:18459:0:99999:7:::
 colord:*:18495:0:99999:7:::
 gnome-initial-setup:*:18495:0:99999:7:::
+rtkit:*:19390:0:99999:7:::
 EOF
 cp /etc/shadow /etc/shadow.orig # We make a copy for a later sanity-compare
 
@@ -226,6 +228,8 @@ geoclue:x:120:
 gdm:x:121:
 scanner:x:122:
 colord:x:123:
+pipewire:x:113:
+rtkit:x:124:
 EOF
 cp /etc/group /etc/group.orig # We make a copy for a later sanity-compare
 
@@ -292,5 +296,7 @@ geoclue:!::
 gdm:!::
 scanner:!::
 colord:!::
+pipewire:!::
+rtkit:!::
 EOF
 cp /etc/gshadow /etc/gshadow.orig # We make a copy for a later sanity-compare

--- a/hooks/000-provide-uids-gids.chroot
+++ b/hooks/000-provide-uids-gids.chroot
@@ -123,6 +123,7 @@ gdm:x:112:121:Gnome Display Manager:/var/lib/gdm3:/bin/false
 colord:x:113:123:colord colour management daemon:/var/lib/colord:/usr/sbin/nologin
 gnome-initial-setup:x:114:65534::/run/gnome-initial-setup/:/bin/false
 rtkit:x:107:124:RealtimeKit,,,:/proc:/usr/sbin/nologin
+pipewire:x:125:125:Pipewire,,,:/proc:/usr/sbin/nologin
 EOF
 cp /etc/passwd /etc/passwd.orig # We make a copy for a later sanity-compare
 
@@ -228,8 +229,8 @@ geoclue:x:120:
 gdm:x:121:
 scanner:x:122:
 colord:x:123:
-pipewire:x:113:
 rtkit:x:124:
+pipewire:x:125:
 EOF
 cp /etc/group /etc/group.orig # We make a copy for a later sanity-compare
 

--- a/hooks/001-zz-add-core-desktop-ppa.chroot
+++ b/hooks/001-zz-add-core-desktop-ppa.chroot
@@ -40,23 +40,6 @@ jXjiWv0P2PA0Vg==
 EOF
 echo "deb http://ppa.launchpad.net/desktop-snappers/core-desktop/ubuntu jammy main" > /etc/apt/sources.list.d/desktop-snappers.list
 
-# enable desktop-snappers PPA
-cat << \EOF > /etc/apt/trusted.gpg.d/rastersoft-gmail-pipewire-core.asc
------BEGIN PGP PUBLIC KEY BLOCK-----
-
-xo0EUHIJfgEEANEe4iUM6AVxnQ9GcI7EAUXo6forbtdM02itbBflLolhWrDpAA3K
-X5qgwTn3PzT7jlFQV8rnmMMKN8Pk/wD63N7qGFZFiv2yl2UFdI/D2gQh5qhGFZf9
-GloLsG48eaeqtSx5aJczzT2u3O+0FGdKLbkl6x6x2HundgLy2YQDR4oTABEBAAHN
-H0xhdW5jaHBhZCBQUEEgZm9yIFNlcmdpbyBDb3N0YXPCuAQTAQIAIgUCUHIJfgIb
-AwYLCQgHAwIGFQgCCQoLBBYCAwECHgECF4AACgkQF3OD0dJgRhjR7gP+LLLehJZh
-a9V7+unXQMTkbtbhTs8DriQ9VvH6R00oE64zrgE8ZYvLKKOhJZFuLWocjaRtgoQ0
-Yq4Efh7xNm2rrDiRnR6lZYc2lJ9/VB0Lkl3BJ2dmW6W0wYjfCa2JSI04uszdQGT/
-1DI6tjh8jnjlbajK0M083aCicHj1ETDge44=
-=GPGk
------END PGP PUBLIC KEY BLOCK-----
-EOF
-echo "deb https://ppa.launchpadcontent.net/rastersoft-gmail/pipewire-core/ubuntu jammy main" > /etc/apt/sources.list.d/pipewire.list
-
 
 apt-get update
 apt-get upgrade -y

--- a/hooks/001-zz-add-core-desktop-ppa.chroot
+++ b/hooks/001-zz-add-core-desktop-ppa.chroot
@@ -40,5 +40,23 @@ jXjiWv0P2PA0Vg==
 EOF
 echo "deb http://ppa.launchpad.net/desktop-snappers/core-desktop/ubuntu jammy main" > /etc/apt/sources.list.d/desktop-snappers.list
 
+# enable desktop-snappers PPA
+cat << \EOF > /etc/apt/trusted.gpg.d/rastersoft-gmail-pipewire-core.asc
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+xo0EUHIJfgEEANEe4iUM6AVxnQ9GcI7EAUXo6forbtdM02itbBflLolhWrDpAA3K
+X5qgwTn3PzT7jlFQV8rnmMMKN8Pk/wD63N7qGFZFiv2yl2UFdI/D2gQh5qhGFZf9
+GloLsG48eaeqtSx5aJczzT2u3O+0FGdKLbkl6x6x2HundgLy2YQDR4oTABEBAAHN
+H0xhdW5jaHBhZCBQUEEgZm9yIFNlcmdpbyBDb3N0YXPCuAQTAQIAIgUCUHIJfgIb
+AwYLCQgHAwIGFQgCCQoLBBYCAwECHgECF4AACgkQF3OD0dJgRhjR7gP+LLLehJZh
+a9V7+unXQMTkbtbhTs8DriQ9VvH6R00oE64zrgE8ZYvLKKOhJZFuLWocjaRtgoQ0
+Yq4Efh7xNm2rrDiRnR6lZYc2lJ9/VB0Lkl3BJ2dmW6W0wYjfCa2JSI04uszdQGT/
+1DI6tjh8jnjlbajK0M083aCicHj1ETDge44=
+=GPGk
+-----END PGP PUBLIC KEY BLOCK-----
+EOF
+echo "deb https://ppa.launchpadcontent.net/rastersoft-gmail/pipewire-core/ubuntu jammy main" > /etc/apt/sources.list.d/pipewire.list
+
+
 apt-get update
 apt-get upgrade -y

--- a/hooks/006-add-gdm.chroot
+++ b/hooks/006-add-gdm.chroot
@@ -61,9 +61,6 @@ rm /etc/systemd/system/display-manager.service
 ln -s gdm.service /lib/systemd/system/display-manager.service
 sed -i '/^Description=/ a # delay until snapd finishes seeding\nAfter=snapd.seeded.service' /lib/systemd/system/gdm.service
 
-# Remove D-Bus service activation for pipewire
-rm -f /etc/systemd/user/pipewire-session-manager.service
-
 # Remove D-Bus service activation files provided by
 # ubuntu-desktop-session snap.
 rm /usr/share/dbus-1/services/org.gnome.Nautilus.service

--- a/hooks/006-add-gdm.chroot
+++ b/hooks/006-add-gdm.chroot
@@ -61,6 +61,9 @@ rm /etc/systemd/system/display-manager.service
 ln -s gdm.service /lib/systemd/system/display-manager.service
 sed -i '/^Description=/ a # delay until snapd finishes seeding\nAfter=snapd.seeded.service' /lib/systemd/system/gdm.service
 
+# Remove D-Bus service activation for pipewire
+rm -f /etc/systemd/user/pipewire-session-manager.service
+
 # Remove D-Bus service activation files provided by
 # ubuntu-desktop-session snap.
 rm /usr/share/dbus-1/services/org.gnome.Nautilus.service

--- a/hooks/006-add-gdm.chroot
+++ b/hooks/006-add-gdm.chroot
@@ -21,7 +21,10 @@ apt install --no-install-recommends -y \
     yaru-theme-icon \
     fonts-ubuntu \
     ubuntu-settings \
-    xdg-user-dirs
+    xdg-user-dirs \
+    pipewire \
+    wireplumber \
+    pipewire-pulse
 
 # Install a basic Ubuntu session
 apt install --no-install-recommends -y \

--- a/hooks/006-add-gdm.chroot
+++ b/hooks/006-add-gdm.chroot
@@ -24,7 +24,13 @@ apt install --no-install-recommends -y \
     xdg-user-dirs \
     pipewire \
     wireplumber \
-    pipewire-pulse
+    pipewire-pulse \
+    pulseaudio-utils \
+    libgsound0 \
+    gsound-tools \
+    gir1.2-gsound-1.0 \
+    libcanberra-pulse \
+    libsnapd-glib1
 
 # Install a basic Ubuntu session
 apt install --no-install-recommends -y \

--- a/hooks/990-ensure-uids-gids.chroot
+++ b/hooks/990-ensure-uids-gids.chroot
@@ -24,13 +24,9 @@ echo "Ensure no docker"
 ! grep -q docker /etc/passwd /etc/shadow /etc/group /etc/gshadow
 rc=$?; [ "$rc" != "0" ] && MISMATCH=1
 
-echo "Ensure no user 107 (ex-docker)"
-cut -d: -f3 /etc/passwd | grep -q 107
-rc=$?; [ "$rc" = "0" ] && MISMATCH=1
+# uid 107 is used by rtkit
 
-echo "Ensure no group 113 (ex-docker)"
-cut -d: -f3 /etc/group | grep -q 113
-rc=$?; [ "$rc" = "0" ] && MISMATCH=1
+# gid 113 is used by pipewire
 
 if [ -n "$MISMATCH" ]; then
     echo "There were changes to the password database."

--- a/hooks/990-ensure-uids-gids.chroot
+++ b/hooks/990-ensure-uids-gids.chroot
@@ -24,7 +24,9 @@ echo "Ensure no docker"
 ! grep -q docker /etc/passwd /etc/shadow /etc/group /etc/gshadow
 rc=$?; [ "$rc" != "0" ] && MISMATCH=1
 
-# uid 107 is used by rtkit
+echo "Ensure no user 107 (ex-docker)"
+cut -d: -f3 /etc/passwd | grep -q 107
+rc=$?; [ "$rc" = "0" ] && MISMATCH=1
 
 echo "Ensure no group 113 (ex-docker)"
 cut -d: -f3 /etc/group | grep -q 113

--- a/hooks/990-ensure-uids-gids.chroot
+++ b/hooks/990-ensure-uids-gids.chroot
@@ -26,7 +26,9 @@ rc=$?; [ "$rc" != "0" ] && MISMATCH=1
 
 # uid 107 is used by rtkit
 
-# gid 113 is used by pipewire
+echo "Ensure no group 113 (ex-docker)"
+cut -d: -f3 /etc/group | grep -q 113
+rc=$?; [ "$rc" = "0" ] && MISMATCH=1
 
 if [ -n "$MISMATCH" ]; then
     echo "There were changes to the password database."

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -74,12 +74,14 @@ parts:
       craftctl default
     override-prime: |
       # Do nothing
+
   splash-theme:
     plugin: dump
     source: https://github.com/snapcore/plymouth-theme-ubuntu-core.git
     source-type: git
     organize:
       ubuntu-core: usr/share/plymouth/themes/ubuntu-core
+
   bootstrap:
     after:
       - probert-deb
@@ -95,5 +97,6 @@ parts:
       craftctl default
     override-prime: |
       craftctl default
+      rm -f etc/systemd/user/pipewire-session-manager.service
       # ensure build-in tests are run
       cd ${CRAFT_PART_SRC} && make test TESTDIR=${CRAFT_PRIME}

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -95,5 +95,6 @@ parts:
       craftctl default
     override-prime: |
       craftctl default
+      rm -f /etc/systemd/user/pipewire-session-manager.service
       # ensure build-in tests are run
       cd ${CRAFT_PART_SRC} && make test TESTDIR=${CRAFT_PRIME}

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -74,14 +74,12 @@ parts:
       craftctl default
     override-prime: |
       # Do nothing
-
   splash-theme:
     plugin: dump
     source: https://github.com/snapcore/plymouth-theme-ubuntu-core.git
     source-type: git
     organize:
       ubuntu-core: usr/share/plymouth/themes/ubuntu-core
-
   bootstrap:
     after:
       - probert-deb

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -95,6 +95,5 @@ parts:
       craftctl default
     override-prime: |
       craftctl default
-      rm -f etc/systemd/user/pipewire-session-manager.service
       # ensure build-in tests are run
       cd ${CRAFT_PART_SRC} && make test TESTDIR=${CRAFT_PRIME}


### PR DESCRIPTION
This is one of the three MRs required for adding audio support to Core Desktop. This one adds the last version of PipeWire, which will be needed to add support of permissions. It also adds some extra packages needed for gnome-control-center to work as expected (for example, without libcanberra-pulse, the audio test doesn't work).