### PR TITLE
hooks: re-enable X11 support in gnome-shell.

### DIFF
--- a/hooks/006-add-gdm.chroot
+++ b/hooks/006-add-gdm.chroot
@@ -100,8 +100,5 @@ X-GDM-SessionRegisters=true
 EOF
 
 # Run GNOME Shell with XWayland disabled
-sed -i 's=/usr/bin/gnome-shell=/usr/bin/gnome-shell --no-x11=g' /usr/lib/systemd/user/org.gnome.Shell@wayland.service
-sed -i 's=/usr/bin/gnome-shell=/usr/bin/gnome-shell --no-x11=g' /usr/lib/systemd/user/org.gnome.Shell@x11.service
-sed -i 's=/usr/bin/gnome-shell=/usr/bin/gnome-shell --no-x11=g' /usr/share/applications/org.gnome.Shell.desktop
 sed -i 's/org.gnome.SettingsDaemon.XSettings;//g' /usr/share/gnome-session/sessions/ubuntu.session
 sed -i 's/org.gnome.SettingsDaemon.XSettings;//g' /usr/share/gnome-session/sessions/gnome-login.session


### PR DESCRIPTION
gsd-xsettings is still disabled, as it is still causing the session to crash.

This relies on a UCD specific rebuild of gnome-shell configured with `-Dsystemd=false`, so Xwayland starts up correctly and doesn't get stuck in `-initfd` mode.