### PR TITLE
hooks: enable gsd-xsettings again

### DIFF
--- a/hooks/006-add-gdm.chroot
+++ b/hooks/006-add-gdm.chroot
@@ -77,6 +77,16 @@ exec /usr/sbin/adduser.real --extrausers "$@"
 EOF
 chmod a+x /usr/sbin/adduser
 
+# Force gsd-xsettings to use the regular DISPLAY connection. If it
+# tries to connect to :1, gnome-shell will not auto-start Xwayland.
+mv /usr/libexec/gsd-xsettings /usr/libexec/gsd-xsettings.real
+cat <<\EOF > /usr/libexec/gsd-xsettings
+#!/bin/sh
+export GNOME_SETUP_DISPLAY="$DISPLAY"
+exec /usr/libexec/gsd-xsettings.real "$@"
+EOF
+chmod a+x /usr/libexec/gsd-xsettings
+
 # accounts-daemon uses systemd to lock down the paths it can write
 # to. That list of paths does not include the extrausers database used
 # by Ubuntu Core.
@@ -98,7 +108,3 @@ Type=Application
 DesktopNames=ubuntu:GNOME
 X-GDM-SessionRegisters=true
 EOF
-
-# Run GNOME Shell with XWayland disabled
-sed -i 's/org.gnome.SettingsDaemon.XSettings;//g' /usr/share/gnome-session/sessions/ubuntu.session
-sed -i 's/org.gnome.SettingsDaemon.XSettings;//g' /usr/share/gnome-session/sessions/gnome-login.session

--- a/hooks/900-cleanup-etc-var.chroot
+++ b/hooks/900-cleanup-etc-var.chroot
@@ -62,7 +62,7 @@ rm -rf /usr/local/lib/python*
 rmdir /etc/cron.daily
 
 # no permanet journal
-rm -rf /var/log/journal
+#rm -rf /var/log/journal
 
 # systemd-tmpfiles creates this new dir now
 rmdir /var/log/private


### PR DESCRIPTION
When gnome-shell starts, it calls gnome-session's D-Bus API to set `GNOME_SETUP_DISPLAY=:1` for future processes it starts. If this environment variable is set, gsd-xsettings will try to connect to this socket in preference to `$DISPLAY`.

Unfortunately, mutter's Xwayland demand start up code only watches for connection attempts on the regular display sockets, so gsd-xsettings hangs. It never registers as a client with gnome-session, so gnome-session asks the shell to display the oops screen after the timeout expires.