### PR TITLE
hooks: try enabling persistent journal again

### DIFF
--- a/hooks/900-cleanup-etc-var.chroot
+++ b/hooks/900-cleanup-etc-var.chroot
@@ -62,7 +62,7 @@ rm -rf /usr/local/lib/python*
 rmdir /etc/cron.daily
 
 # no permanet journal
-#rm -rf /var/log/journal
+rm -rf /var/log/journal
 
 # systemd-tmpfiles creates this new dir now
 rmdir /var/log/private
@@ -72,6 +72,11 @@ rm -rf /var/log/gdm3
 
 # clean leftovers from the build
 rm /var/log/*
+
+# Re-enable journal
+mkdir /var/log/journal
+chown root:systemd-journal /var/log/journal
+chmod 2755 /var/log/journal
 
 # no "local" on core22
 # shellcheck disable=SC2114


### PR DESCRIPTION
A later command in the hooks broke when we stopped deleting /var/log/journal. So go back to deleting it, then re-create it after /var/log is cleared.