### PR TITLE
hooks: don't reuse the docker uid for rtkit

### DIFF
--- a/hooks/000-provide-uids-gids.chroot
+++ b/hooks/000-provide-uids-gids.chroot
@@ -122,8 +122,8 @@ geoclue:x:111:120::/var/lib/geoclue:/bin/false
 gdm:x:112:121:Gnome Display Manager:/var/lib/gdm3:/bin/false
 colord:x:113:123:colord colour management daemon:/var/lib/colord:/usr/sbin/nologin
 gnome-initial-setup:x:114:65534::/run/gnome-initial-setup/:/bin/false
-rtkit:x:107:124:RealtimeKit,,,:/proc:/usr/sbin/nologin
-pipewire:x:125:125:Pipewire,,,:/proc:/usr/sbin/nologin
+rtkit:x:115:124:RealtimeKit,,,:/proc:/usr/sbin/nologin
+pipewire:x:116:125:Pipewire,,,:/proc:/usr/sbin/nologin
 EOF
 cp /etc/passwd /etc/passwd.orig # We make a copy for a later sanity-compare
 


### PR DESCRIPTION
The latest snap build is failing due to reuse of uid 107 (the uid previously used by docker). Adjust the uids for rtkit and pipewire users to compensate.