### PR TITLE
UCD-114: add libspa-bluetooth package

### DIFF
--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -100,6 +100,7 @@ PACKAGES=(
     libp11-3
     libpam-modules
     libpam-systemd
+    libspa-0.2-bluetooth
     netcat-openbsd
     netplan.io
     opensc


### PR DESCRIPTION
This package is required to have bluetooth audio support.