### PR TITLE
Remove org.gnome.Shell.Screencast.service

### DIFF
--- a/hooks/006-add-gdm.chroot
+++ b/hooks/006-add-gdm.chroot
@@ -67,6 +67,7 @@ rm /usr/share/dbus-1/services/org.gnome.Nautilus.service
 rm /usr/share/dbus-1/services/org.gnome.Terminal.service
 rm /usr/share/dbus-1/services/org.freedesktop.impl.portal.desktop.gnome.service
 rm /usr/share/dbus-1/services/org.freedesktop.impl.portal.desktop.gtk.service
+rm /usr/share/dbus-1/services/org.gnome.Shell.Screencast.service
 
 # Remove systemd activation in services managed by
 # ubuntu-desktop-session snap


### PR DESCRIPTION
This removes org.gnome.Shell.Screencast.service to prevent activation on screen recording as an unconfined service.