### PR TITLE
hooks, static: add session wrapper script, and make /etc/gdm3/custom.conf writable

### DIFF
--- a/hooks/006-add-gdm.chroot
+++ b/hooks/006-add-gdm.chroot
@@ -114,15 +114,7 @@ sed -i "/^ReadWritePaths=/ a \\  /var/lib/extrausers/ \\\\" \
 ## Re-enable the language page of gnome-initial-setup
 #sed -i '/skip=/ s/language;*//' /usr/share/gnome-initial-setup/vendor.conf
 
-# Register the confined session as the only option in GDM
-rm -f /usr/share/wayland-sessions/*.desktop
-cat <<\EOF > /usr/share/wayland-sessions/ubuntu-desktop-session.desktop
-[Desktop Entry]
-Name=Ubuntu (confined)
-Comment=This session logs you into Ubuntu
-Exec=/snap/ubuntu-desktop-session/current/session-wrapper.sh
-#TryExec=/snap/ubuntu-desktop-session/current/session-wrapper.sh
-Type=Application
-DesktopNames=ubuntu:GNOME
-X-GDM-SessionRegisters=true
-EOF
+# Remove regular Ubuntu sessions, so only confined session is available
+rm -f /usr/share/wayland-sessions/ubuntu.desktop
+rm -f /usr/share/wayland-sessions/ubuntu-wayland.desktop
+rm -f /usr/share/xsessions/ubuntu-xorg.desktop

--- a/hooks/006-add-gdm.chroot
+++ b/hooks/006-add-gdm.chroot
@@ -118,3 +118,8 @@ sed -i "/^ReadWritePaths=/ a \\  /var/lib/extrausers/ \\\\" \
 rm -f /usr/share/wayland-sessions/ubuntu.desktop
 rm -f /usr/share/wayland-sessions/ubuntu-wayland.desktop
 rm -f /usr/share/xsessions/ubuntu-xorg.desktop
+
+# Move GDM config to writable directory
+mkdir -p /etc/writable/gdm3
+mv /etc/gdm3/custom.conf /etc/writable/gdm3/custom.conf
+ln -s ../writable/gdm3/custom.conf /etc/gdm3/custom.conf

--- a/static/usr/bin/core-desktop-session-wrapper.sh
+++ b/static/usr/bin/core-desktop-session-wrapper.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# This script runs outside of snap confinement as a wrapper around the
+# confined desktop session.
+snap_cmd="$1"
+snap_name="$(echo "$snap_cmd" | cut -d . -f 1)"
+
+# Set up PATH and XDG_DATA_DIRS to allow calling snaps
+if [ -f /snap/snapd/current/etc/profile.d/apps-bin-path.sh ]; then
+    source /snap/snapd/current/etc/profile.d/apps-bin-path.sh
+fi
+
+export XDG_CURRENT_DESKTOP=ubuntu:GNOME
+export GSETTINGS_BACKEND=keyfile
+
+dbus-update-activation-environment --systemd --all
+
+# Don't set this in our own environment, since it will make
+# gnome-session believe it is running in X mode
+dbus-update-activation-environment --systemd DISPLAY=:0 WAYLAND_DISPLAY=wayland-0
+
+# Set up a background task to wait for gnome-session to create its
+# Xauthority file, and copy it to a location snaps will be able to
+# see.
+function fixup_xauthority() {
+    while :; do
+        sleep 1s
+        xauth_file="$(ls -1t $XDG_RUNTIME_DIR/snap.$snap_name/.mutter-Xwaylandauth.* | head -n1)"
+        if [ -f "$xauth_file" ]; then
+            cp "$xauth_file" $XDG_RUNTIME_DIR/.Xauthority
+            return
+        fi
+    done
+}
+fixup_xauthority &
+
+# Symlink the Wayland socket from the snap's private directory
+ln -sf "snap.$snap_name/wayland-0" $XDG_RUNTIME_DIR/wayland-0
+# Symlink sockets for pipewire and pipewire-pulse
+ln -sf "snap.$snap_name/pipewire-0" $XDG_RUNTIME_DIR/pipewire-0
+ln -sf "snap.$snap_name/pulse" $XDG_RUNTIME_DIR/pulse
+
+exec "/snap/bin/$snap_cmd"

--- a/static/usr/share/wayland-sessions/ubuntu-desktop-session.desktop
+++ b/static/usr/share/wayland-sessions/ubuntu-desktop-session.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Name=Ubuntu (confined)
+Comment=This session logs you into Ubuntu
+Exec=core-desktop-session-wrapper.sh ubuntu-desktop-session
+TryExec=/snap/bin/ubuntu-desktop-session
+Type=Application
+DesktopNames=ubuntu:GNOME
+X-GDM-SessionRegisters=true


### PR DESCRIPTION
This PR adds a version of the ubuntu-desktop-session snap's `session-wrapper.sh` script to the base snap, so it can potentially be used by other desktop session snaps.

I took the opportunity to simplify the snap a little too:

1. the script now takes the session snap command as an argument, so it should work with snaps other than ubuntu-desktop-session.
2. just symlink sockets from `$XDG_RUNTIME_DIR/snap.$snap_name` to `$XDG_RUNTIME_DIR`. We were hard linking sockets before in the hope that it would make things easier with AppArmor, but that turned out not to be the case. We also don't have to wait for the session snap to create the sockets before creating symlinks, so this gets rid of some of the background jobs.

As well as updating `ubuntu-desktop-session.desktop` to use the new wrapper script, I moved it to `static/` so it's not stuck in the middle of a hook script.

Secondly, I've made GDM's configuration file writable by moving it to `/etc/writable` and adding a symlink. This lets devices turn on auto-login, for instance. It's possible this change will cause upgrade problems, since the contents of `/etc/writable` won't be synchronised on a snap upgrade. I'm not sure it is worth worrying about at this point.