### PR TITLE
remove colord-session

### DIFF
--- a/hooks/006-add-gdm.chroot
+++ b/hooks/006-add-gdm.chroot
@@ -71,6 +71,7 @@ rm /usr/share/dbus-1/services/org.freedesktop.impl.portal.desktop.gtk.service
 rm /usr/share/dbus-1/services/org.gnome.Shell.Screencast.service
 rm -f /usr/share/dbus-1/services/org.freedesktop.IBus.service
 rm -f /usr/share/dbus-1/services/org.freedesktop.portal.IBus.service
+rm -f /usr/share/dbus-1/services/org.freedesktop.ColorHelper.service
 
 # Remove systemd activation in services managed by
 # ubuntu-desktop-session snap

--- a/hooks/006-add-gdm.chroot
+++ b/hooks/006-add-gdm.chroot
@@ -82,6 +82,7 @@ rm -f /etc/systemd/user/default.target.wants/pipewire*
 rm -f /usr/lib/systemd/user/org.freedesktop.IBus.session.GNOME.service
 rm -f /usr/lib/systemd/user/org.freedesktop.IBus.session.generic.service
 rm -f /usr/lib/systemd/user/gnome-session.target.wants/org.freedesktop.IBus.session.GNOME.service
+rm -f /usr/lib/systemd/user/colord-session.service
 
 # Disable console-conf, since it interferes with GDM taking over
 # /dev/tty1.  Due to the ExecStartPre/ExecStopPost commands, we can't


### PR DESCRIPTION
Prevent launching colord-session to allow it to be dbus activated via ubuntu-desktop-session