### PR TITLE
Fix gnome-shell

### DIFF
--- a/hooks/006-add-gdm.chroot
+++ b/hooks/006-add-gdm.chroot
@@ -34,7 +34,9 @@ apt install --no-install-recommends -y \
     ibus
 
 # Install a basic Ubuntu session
-apt install --no-install-recommends -y \
+apt install --no-install-recommends -y --allow-downgrades \
+    gnome-shell=42.5-0ubuntu1+ucd2\
+    gnome-shell-common=42.5-0ubuntu1+ucd2 \
     ubuntu-session \
     gnome-terminal \
     gnome-settings-daemon \


### PR DESCRIPTION
There was a gnome-shell update in jammy, and it is breaking Core Desktop. This patch ensures that the version from the Core Desktop PPA is used.

This is a temporary fix, while waiting for an updated version in the PPA.