### PR TITLE
hooks: fix opening links from GTK

### DIFF
--- a/hooks/500-create-xdg.chroot
+++ b/hooks/500-create-xdg.chroot
@@ -1,0 +1,30 @@
+#!/bin/sh -ex
+
+echo "I: Creating xdg helper"
+
+mv /usr/bin/xdg-open /usr/bin/xdg-open-original
+cat >/usr/bin/xdg-open <<'EOF'
+#!/bin/sh
+exec snapctl user-open "$@"
+EOF
+chmod 755 /usr/bin/xdg-open
+
+# corresponding .desktop entry, needed for mimetype registration
+mkdir -p /usr/share/applications
+cat >/usr/share/applications/xdg-open.desktop <<EOF
+[Desktop Entry]
+Version=1.0
+Name=Url Handler Script
+Exec=/usr/bin/xdg-open %u
+MimeType=x-scheme-handler/http;x-scheme-handler/https;x-scheme-handler/mailto;x-scheme-handler/help;
+Type=Application
+EOF
+
+# define xdg-open as the default handler for common types
+cat >/usr/share/applications/mimeapps.list <<EOF
+[Default Applications]
+x-scheme-handler/http=xdg-open.desktop
+x-scheme-handler/https=xdg-open.desktop
+x-scheme-handler/mailto=xdg-open.desktop
+x-scheme-handler/help=xdg-open.desktop
+EOF


### PR DESCRIPTION
This patch allows to open links from GTK programs inside the desktop session. It also requires https://github.com/canonical/ubuntu-core-desktop-snapd/pull/18 to work. The patch just ensures that all programs call xdg-open, no matter in which session they are, and it will invoke the original xdg-open script through DBus.