### PR TITLE
Delay gdm until after cloud-config is complete

### DIFF
--- a/hooks/006-add-gdm.chroot
+++ b/hooks/006-add-gdm.chroot
@@ -60,7 +60,8 @@ mv /etc/dbus-1/system.d/gdm.conf /usr/share/dbus-1/system.d/
 # Move display-manager.service symlink out of /etc
 rm /etc/systemd/system/display-manager.service
 ln -s gdm.service /lib/systemd/system/display-manager.service
-sed -i '/^Description=/ a # delay until snapd finishes seeding\nAfter=snapd.seeded.service' /lib/systemd/system/gdm.service
+# Delay gdm until snapd.seeded and cloud-init are complete
+sed -i '/^Description=/ a # delay until snapd finishes seeding\nAfter=snapd.seeded.service cloud-init.target' /lib/systemd/system/gdm.service
 
 # Remove D-Bus service activation files provided by
 # ubuntu-desktop-session snap.


### PR DESCRIPTION
GDM in ubuntu applies this logic, so we should do the same for desktop on core

https://salsa.debian.org/gnome-team/gdm/-/blob/ubuntu/master/debian/patches/ubuntu/start-after-cloudinit.patch