### PR TITLE
Allow to test debian packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,16 @@ worked as expected.
 The `.test` scripts will be run after building with snapcraft or when
 doing a manual "make test" in the source tree.
 
+# Testing custom .deb packages
+
+Sometimes, modified .deb packages are required. These are uploaded into
+an specific PPA to make them available for building, but during development,
+they must be tested locally before. To do so, it is possible to create
+a folder called *test-debs* and copy inside the custom .deb packages.
+That folder is managed like a standard APT repository, and it is pinned
+to the maximum priority, thus ensuring that they will be installed over
+any other package.
+
 # Bootchart
 
 It is possible to enable bootcharts by adding `core.bootchart` to the

--- a/build-package.sh
+++ b/build-package.sh
@@ -35,7 +35,7 @@ case "$1" in
         # number. This allows to easily test packages before uploading them to the
         # Core Desktop PPA.
         if [ -e ${CRAFT_PROJECT_DIR}/test-debs ]; then
-            /bin/cp -a ${CRAFT_PROJECT_DIR}/test-debs/*.deb ${CRAFT_STAGE}/local-debs/
+            cp -a ${CRAFT_PROJECT_DIR}/test-debs/*.deb ${CRAFT_STAGE}/local-debs/
         fi
         cd "${CRAFT_STAGE}/local-debs"
         dpkg-scanpackages . >Packages

--- a/build-package.sh
+++ b/build-package.sh
@@ -28,8 +28,14 @@ case "$1" in
         ;;
     stage)
         craftctl default
+        # It is possible to add .deb packages into a "test-debs" folder in the
+        # project. These packages are managed as an APT source, and pinned to
+        # have maximum priority, so, if installed from APT, they will have preference
+        # over the packages in the standard and PPA repositories, no matter their version
+        # number. This allows to easily test packages before uploading them to the
+        # Core Desktop PPA.
         if [ -e ${CRAFT_PROJECT_DIR}/test-debs ]; then
-            /bin/cp -a ${CRAFT_PROJECT_DIR}/test-debs/* ${CRAFT_STAGE}/local-debs/
+            cp -a ${CRAFT_PROJECT_DIR}/test-debs/*.deb ${CRAFT_STAGE}/local-debs/
         fi
         cd "${CRAFT_STAGE}/local-debs"
         dpkg-scanpackages . >Packages

--- a/build-package.sh
+++ b/build-package.sh
@@ -28,6 +28,9 @@ case "$1" in
         ;;
     stage)
         craftctl default
+        if [ -e ${CRAFT_PROJECT_DIR}/test-debs ]; then
+            /bin/cp -a ${CRAFT_PROJECT_DIR}/test-debs/* ${CRAFT_STAGE}/local-debs/
+        fi
         cd "${CRAFT_STAGE}/local-debs"
         dpkg-scanpackages . >Packages
         apt-ftparchive release . >Release

--- a/build-package.sh
+++ b/build-package.sh
@@ -35,7 +35,7 @@ case "$1" in
         # number. This allows to easily test packages before uploading them to the
         # Core Desktop PPA.
         if [ -e ${CRAFT_PROJECT_DIR}/test-debs ]; then
-            cp -a ${CRAFT_PROJECT_DIR}/test-debs/*.deb ${CRAFT_STAGE}/local-debs/
+            /bin/cp -a ${CRAFT_PROJECT_DIR}/test-debs/*.deb ${CRAFT_STAGE}/local-debs/
         fi
         cd "${CRAFT_STAGE}/local-debs"
         dpkg-scanpackages . >Packages


### PR DESCRIPTION
Sometimes it is desirable to test .deb packages in the core22 system before uploading them to the core-desktop PPA.

This PR allows to do this, by copying any .deb file placed in the "test-debs" folder in the project dir, and making them available to APT with the maximum priority, thus overriding any other package with the same name.