### PR TITLE
Skip the goa page in gnome-initial-setup

### DIFF
--- a/hooks/006-add-gdm.chroot
+++ b/hooks/006-add-gdm.chroot
@@ -120,8 +120,8 @@ chmod a+x /usr/libexec/gsd-xsettings
 sed -i "/^ReadWritePaths=/ a \\  /var/lib/extrausers/ \\\\" \
     /usr/lib/systemd/system/accounts-daemon.service
 
-## Re-enable the language page of gnome-initial-setup
-#sed -i '/skip=/ s/language;*//' /usr/share/gnome-initial-setup/vendor.conf
+## Skip goa page in gnome-initial-setup
+sed -i 's/skip=language/skip=language;goa/g' /usr/share/gnome-initial-setup/vendor.conf
 
 # Hide gnome-terminal by default
 sed -i 's/OnlyShowIn=/NoDisplay=true\nOnlyShowIn=/g' /usr/share/applications/org.gnome.Terminal.desktop


### PR DESCRIPTION
the goa page doesn't work, let's skip it for now.