### PR TITLE
Allow to connect specific plugs during installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ install:
 	/bin/cp -a static/* $(DESTDIR)
 	mkdir -p $(DESTDIR)/install-data
 	/bin/cp -r $(CRAFT_STAGE)/local-debs $(DESTDIR)/install-data/local-debs
+	$(CRAFT_PROJECT_DIR)/generate-connections.py $(CRAFT_PROJECT_DIR)/snap-connections.txt $(DESTDIR)/snap-connections.sh
 	# customize
 	set -eux; for f in ./hooks/[0-9]*.chroot; do		\
 		base="$$(basename "$${f}")";			\
@@ -41,6 +42,7 @@ install:
 		rm "$(DESTDIR)/install-data/$${base}";		\
 	done
 	rm -rf $(DESTDIR)/install-data
+	rm -f $(DESTDIR)/snap-connections.sh
 
 	# see https://github.com/systemd/systemd/blob/v247/src/shared/clock-util.c#L145
 	touch $(DESTDIR)/usr/lib/clock-epoch

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ install:
 	/bin/cp -a static/* $(DESTDIR)
 	mkdir -p $(DESTDIR)/install-data
 	/bin/cp -r $(CRAFT_STAGE)/local-debs $(DESTDIR)/install-data/local-debs
-	$(CRAFT_PROJECT_DIR)/generate-connections.py $(CRAFT_PROJECT_DIR)/snap-connections.txt $(DESTDIR)/snap-connections.sh
+	$(CRAFT_PROJECT_DIR)/generate-connections.py $(CRAFT_PROJECT_DIR)/snap-connections.txt $(DESTDIR)/usr/libexec/snap-connections.sh
 	# customize
 	set -eux; for f in ./hooks/[0-9]*.chroot; do		\
 		base="$$(basename "$${f}")";			\
@@ -42,7 +42,6 @@ install:
 		rm "$(DESTDIR)/install-data/$${base}";		\
 	done
 	rm -rf $(DESTDIR)/install-data
-	rm -f $(DESTDIR)/snap-connections.sh
 
 	# see https://github.com/systemd/systemd/blob/v247/src/shared/clock-util.c#L145
 	touch $(DESTDIR)/usr/lib/clock-epoch

--- a/README.md
+++ b/README.md
@@ -122,6 +122,24 @@ That folder is managed like a standard APT repository, and it is pinned
 to the maximum priority, thus ensuring that they will be installed over
 any other package.
 
+# Connect specific plugs during installation
+
+Sometimes, it is required to connect some plugs that, by default, aren't
+being connected. Although the right way of doing it should be modifying
+the gadget-desktop snap, there is a way of doing it for quick tests.
+Just edit the file *snap-connections.txt* in the project's root folder,
+and add one line with each plug to connect (and, if needed, the slot).
+For example, to ensure that the *locale-control* plug is connected in the
+*ubuntu-core-desktop* snap, just edit that file and add this line:
+
+    ubuntu-core-desktop:locale-control
+
+When this file exists, a shell script file is created that tries to connect
+each plug; also a systemd service called *manual-plug-connection.service*
+is created and enabled, that launches that shell script. The script tries
+to connect all plugs once each second, and only when all succeeded, it exits
+and disables the service, thus it won't be run again in next boots.
+
 # Bootchart
 
 It is possible to enable bootcharts by adding `core.bootchart` to the

--- a/generate-connections.py
+++ b/generate-connections.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+
+import sys
+import os
+
+if len(sys.argv) != 3:
+    print("Usage: generate-connections.py origin-file destination-file")
+    sys.exit(1)
+
+origin = sys.argv[1]
+destination = sys.argv[2]
+
+if not os.path.isfile(origin):
+    sys.exit(0)
+
+with open(origin, "rt") as origin_data:
+    with open(destination, "wt") as destination_data:
+        destination_data.write("""#!/bin/sh
+
+while : ; do
+    retval=0
+""")
+        for line in origin_data.readlines():
+            line = line.strip()
+            if line == "":
+                continue
+            if line[0] == '#':
+                continue
+            snap_name = line[:line.find(":")]
+            destination_data.write(f"""
+    if /usr/bin/snap list {snap_name}; then
+        if ! /usr/bin/snap connect {line}; then
+            retval=1
+        fi
+    else
+        retval=1
+    fi
+""")
+        destination_data.write("""
+    if [ "$retval" = "0" ] ; then
+        systemctl disable manual-plug-connection.service
+        exit 0
+    fi
+    sleep 1
+done
+""")

--- a/generate-connections.py
+++ b/generate-connections.py
@@ -2,6 +2,7 @@
 
 import sys
 import os
+import stat
 
 if len(sys.argv) != 3:
     print("Usage: generate-connections.py origin-file destination-file")
@@ -12,6 +13,10 @@ destination = sys.argv[2]
 
 if not os.path.isfile(origin):
     sys.exit(0)
+
+destination_dir = os.path.dirname(destination)
+if not os.path.exists(destination_dir):
+    os.makedirs(destination_dir)
 
 with open(origin, "rt") as origin_data:
     with open(destination, "wt") as destination_data:
@@ -44,3 +49,5 @@ while : ; do
     sleep 1
 done
 """)
+
+os.chmod(destination, 0o755)

--- a/hooks/993-connect-snaps.chroot
+++ b/hooks/993-connect-snaps.chroot
@@ -2,10 +2,7 @@
 
 set -e
 
-if [ -f /snap-connections.sh ]; then
-    mkdir -p /usr/libexec
-    cp /snap-connections.sh /usr/libexec/
-    chmod 755 /usr/libexec/snap-connections.sh
+if [ -f /usr/libexec/snap-connections.sh ]; then
     cat >/etc/systemd/system/manual-plug-connection.service <<'EOF'
 [Unit]
 Description=Manually connect snap plugs.

--- a/hooks/993-connect-snaps.chroot
+++ b/hooks/993-connect-snaps.chroot
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+set -e
+
+if [ -f /snap-connections.sh ]; then
+    mkdir -p /usr/libexec
+    cp /snap-connections.sh /usr/libexec/
+    chmod 755 /usr/libexec/snap-connections.sh
+    cat >/etc/systemd/system/manual-plug-connection.service <<'EOF'
+[Unit]
+Description=Manually connect snap plugs.
+
+[Service]
+Type=simple
+Restart=no
+ExecStart=/usr/libexec/snap-connections.sh
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    systemctl enable manual-plug-connection.service
+fi


### PR DESCRIPTION
Sometimes it is needed to be able to connect some plugs during installation. Although the right way of doing it is by editing the gadget-desktop snap, this is cumbersome for quick tests.

This patch adds a quick&dirty way of connecting the plugs during installation. It basically creates a systemd service that is run at startup and tries to connect the specified plugs. When it succeeds, it automatically disables itself.

This method must be used only during tests, never for production.