### PR TITLE
hooks: set VARIANT_ID=desktop in /usr/lib/os-release

### DIFF
--- a/hooks/018-set-os-release.chroot
+++ b/hooks/018-set-os-release.chroot
@@ -6,6 +6,8 @@ VERSION="22"
 ID=ubuntu-core
 PRETTY_NAME="Ubuntu Core 22"
 VERSION_ID="22"
+VARIANT_ID=desktop
+VARIANT="Desktop"
 HOME_URL="https://snapcraft.io/"
 BUG_REPORT_URL="https://bugs.launchpad.net/snappy/"
 EOF


### PR DESCRIPTION
The `release.OnCoreDesktop` check merged to upstream snapd in @robert-ancell's https://github.com/snapcore/snapd/pull/13041 depends on us setting `VARIANT_ID=desktop` in `/usr/lib/os-release` in the root file system. This change does that.