### PR TITLE
Update XDG folders when changing locale

### DIFF
--- a/hooks/002-add-locales.chroot
+++ b/hooks/002-add-locales.chroot
@@ -13,7 +13,7 @@ for PATH in "$ORIG_BASE_DIR"/*; do
     LANG=$(/bin/basename "$PATH")
     DESTINATION="$DEST_BASE_DIR"/"$LANG"/LC_MESSAGES/
     /bin/mkdir -p "$DESTINATION"
-    for FILENAME in coreutils.mo ibus10.mo gtk40.mo gtk30.mo gnome-shell.mo gnome-control-center-2.0.mo gnome-desktop-3.0.mo gnome-initial-setup.mo gnome-menus-3.0.mo language-selector.mo xdg-desktop-portal-gnome.mo xdg-desktop-portal.mo ibus-chewing.mo nautilus.mo nautilus-share.mo gnome-terminal.mo gdm.mo; do
+    for FILENAME in coreutils.mo ibus10.mo gtk40.mo gtk30.mo gnome-shell.mo gnome-control-center-2.0.mo gnome-desktop-3.0.mo gnome-initial-setup.mo gnome-menus-3.0.mo language-selector.mo xdg-desktop-portal-gnome.mo xdg-desktop-portal.mo ibus-chewing.mo nautilus.mo nautilus-share.mo gnome-terminal.mo gdm.mo xdg-user-dirs.mo xdg-user-dirs-gtk.mo; do
         FULL_PATH="$PATH"/LC_MESSAGES/"$FILENAME"
         if [ -f "$FULL_PATH" ]; then
             /bin/cp -a "$FULL_PATH" "$DESTINATION"

--- a/hooks/006-add-gdm.chroot
+++ b/hooks/006-add-gdm.chroot
@@ -15,6 +15,7 @@ apt install --no-install-recommends -y \
     xwayland \
     libgl1-mesa-dri \
     locales-all \
+    locales \
     zenity \
     yaru-theme-gtk \
     yaru-theme-gnome-shell \
@@ -46,7 +47,8 @@ apt install --no-install-recommends -y \
     spice-vdagent \
     xdg-desktop-portal \
     xdg-desktop-portal-gnome \
-    xdg-desktop-portal-gtk
+    xdg-desktop-portal-gtk \
+    xdg-user-dirs-gtk
 
 # Remove setuid from some executables we're not using
 chmod u-s,g-s /usr/bin/pkexec


### PR DESCRIPTION
When the user changes the locale, the XDG folders should be renamed to their translated names. This is done by xdg-user-dirs-gtk-update and xdg-user-dirs-update. Unfortunately, the former was missing, and also some .mo files are required for them to work.

This patch adds everything.

Unfortunately, there is still some problem: when the folders are renamed, the desktop icons disappear. After rebooting/restarting the Gnome Shell session, the icons still don't appear (it seems to be some problem with nautilus). After a new reboot/restart, the icons finally do appear.