### PR TITLE
Use ubuntu core desktop init for setup

### DIFF
--- a/hooks/006-add-gdm.chroot
+++ b/hooks/006-add-gdm.chroot
@@ -10,7 +10,6 @@ trap 'umount /proc' EXIT
 
 apt install --no-install-recommends -y \
     gdm3 \
-    gnome-initial-setup \
     polkitd \
     xwayland \
     libgl1-mesa-dri \
@@ -122,9 +121,6 @@ chmod a+x /usr/libexec/gsd-xsettings
 # by Ubuntu Core.
 sed -i "/^ReadWritePaths=/ a \\  /var/lib/extrausers/ \\\\" \
     /usr/lib/systemd/system/accounts-daemon.service
-
-## Skip goa page in gnome-initial-setup
-sed -i 's/skip=language/skip=language;goa/g' /usr/share/gnome-initial-setup/vendor.conf
 
 # Hide gnome-terminal by default
 sed -i 's/OnlyShowIn=/NoDisplay=true\nOnlyShowIn=/g' /usr/share/applications/org.gnome.Terminal.desktop

--- a/hooks/010-configure-system-setup-tool.chroot
+++ b/hooks/010-configure-system-setup-tool.chroot
@@ -2,16 +2,27 @@
 
 set -e
 
-apt install zenity
+apt install --no-install-recommends -y zenity gnome-initial-setup
 
 # Launch ubuntu-core-desktop-init instead of gnome-initial-setup
-cp /usr/share/applications/gnome-initial-setup.desktop /usr/share/applications/ubuntu-core-desktop-init.desktop
+mv /usr/share/applications/gnome-initial-setup.desktop /usr/share/applications/ubuntu-core-desktop-init.desktop
 sed -i 's#/usr/libexec/gnome-initial-setup#/usr/libexec/launch-setup.sh#g' /usr/share/applications/ubuntu-core-desktop-init.desktop
 
 sed -i 's#gnome-initial-setup#ubuntu-core-desktop-init#g' /usr/share/gnome-session/sessions/gnome-initial-setup.session
 
 cp /usr/share/polkit-1/rules.d/20-gnome-initial-setup.rules /usr/share/polkit-1/rules.d/20-ubuntu-core-desktop-init.rules
 sed -i 's#gnome-initial-setup#ubuntu-core-desktop-init#g' /usr/share/polkit-1/rules.d/20-ubuntu-core-desktop-init.rules
+
+# remove unneeded files to free space
+rm -f /usr/lib/systemd/user/gnome-session.target.wants/gnome-initial-setup-copy-worker.service
+rm -f /usr/lib/systemd/user/gnome-session.target.wants/gnome-initial-setup-first-login.service
+rm -f /usr/share/gnome-initial-setup/vendor.conf
+rm -rf /usr/share/doc/gnome-initial-setup
+rm -f /usr/libexec/gnome-initial-setup*
+rm -f /usr/lib/systemd/user/gnome-initial-setup-copy-worker.service
+rm -f /usr/lib/systemd/user/gnome-initial-setup-first-login.service
+rm -f /etc/xdg/autostart/gnome-initial-setup-copy-worker.desktop
+rm -f /etc/xdg/autostart/gnome-initial-setup-first-login.desktop
 
 # write the launch script
 cat > /usr/libexec/launch-setup.sh <<EOF

--- a/hooks/010-configure-system-setup-tool.chroot
+++ b/hooks/010-configure-system-setup-tool.chroot
@@ -6,12 +6,9 @@ apt install --no-install-recommends -y zenity gnome-initial-setup
 
 # Launch ubuntu-core-desktop-init instead of gnome-initial-setup
 mv /usr/share/applications/gnome-initial-setup.desktop /usr/share/applications/ubuntu-core-desktop-init.desktop
-sed -i 's#/usr/libexec/gnome-initial-setup#/usr/libexec/launch-setup.sh#g' /usr/share/applications/ubuntu-core-desktop-init.desktop
+sed -i 's#/usr/libexec/gnome-initial-setup#/snap/ubuntu-core-desktop-init/current/bin/ubuntu_init#g' /usr/share/applications/ubuntu-core-desktop-init.desktop
 
 sed -i 's#gnome-initial-setup#ubuntu-core-desktop-init#g' /usr/share/gnome-session/sessions/gnome-initial-setup.session
-
-cp /usr/share/polkit-1/rules.d/20-gnome-initial-setup.rules /usr/share/polkit-1/rules.d/20-ubuntu-core-desktop-init.rules
-sed -i 's#gnome-initial-setup#ubuntu-core-desktop-init#g' /usr/share/polkit-1/rules.d/20-ubuntu-core-desktop-init.rules
 
 # remove unneeded files to free space
 rm -f /usr/lib/systemd/user/gnome-session.target.wants/gnome-initial-setup-copy-worker.service
@@ -23,14 +20,4 @@ rm -f /usr/lib/systemd/user/gnome-initial-setup-copy-worker.service
 rm -f /usr/lib/systemd/user/gnome-initial-setup-first-login.service
 rm -f /etc/xdg/autostart/gnome-initial-setup-copy-worker.desktop
 rm -f /etc/xdg/autostart/gnome-initial-setup-first-login.desktop
-
-# write the launch script
-cat > /usr/libexec/launch-setup.sh <<EOF
-#!/bin/sh
-
-# launch the configuration program
-export G_MESSAGES_DEBUG=all
-/snap/ubuntu-core-desktop-init/current/bin/ubuntu_init
-EOF
-chmod 755 /usr/libexec/launch-setup.sh
 

--- a/hooks/010-configure-system-setup-tool.chroot
+++ b/hooks/010-configure-system-setup-tool.chroot
@@ -30,11 +30,6 @@ cat > /usr/libexec/launch-setup.sh <<EOF
 
 # launch the configuration program
 export G_MESSAGES_DEBUG=all
-#if [ -f "/usr/libexec/ubuntu_init" ]; then
-#    /usr/libexec/ubuntu_init
-#else
-#    /snap/ubuntu-core-desktop-init/current/bin/ubuntu_init
-#fi
 /snap/ubuntu-core-desktop-init/current/bin/ubuntu_init
 EOF
 chmod 755 /usr/libexec/launch-setup.sh

--- a/hooks/010-configure-system-setup-tool.chroot
+++ b/hooks/010-configure-system-setup-tool.chroot
@@ -30,12 +30,12 @@ cat > /usr/libexec/launch-setup.sh <<EOF
 
 # launch the configuration program
 export G_MESSAGES_DEBUG=all
-if [ -f "/usr/libexec/ubuntu_init" ]; then
-    /usr/libexec/ubuntu_init
-else
-    /snap/ubuntu-core-desktop-init/current/bin/ubuntu_init
-fi
-
+#if [ -f "/usr/libexec/ubuntu_init" ]; then
+#    /usr/libexec/ubuntu_init
+#else
+#    /snap/ubuntu-core-desktop-init/current/bin/ubuntu_init
+#fi
+/snap/ubuntu-core-desktop-init/current/bin/ubuntu_init
 EOF
 chmod 755 /usr/libexec/launch-setup.sh
 

--- a/hooks/010-configure-system-setup-tool.chroot
+++ b/hooks/010-configure-system-setup-tool.chroot
@@ -2,7 +2,7 @@
 
 set -e
 
-apt install --no-install-recommends -y zenity gnome-initial-setup
+apt install --no-install-recommends -y gnome-initial-setup
 
 # Launch ubuntu-core-desktop-init instead of gnome-initial-setup
 mv /usr/share/applications/gnome-initial-setup.desktop /usr/share/applications/ubuntu-core-desktop-init.desktop

--- a/hooks/010-configure-system-setup-tool.chroot
+++ b/hooks/010-configure-system-setup-tool.chroot
@@ -30,13 +30,11 @@ cat > /usr/libexec/launch-setup.sh <<EOF
 
 # launch the configuration program
 export G_MESSAGES_DEBUG=all
-/snap/ubuntu-core-desktop-init/current/bin/ubuntu_init
-
-# Inform the user that the system will be rebooted.
-# Maybe we need a way of translating this...
-zenity --info --text="Installation complete.\nSystem will be rebooted"
-
-reboot
+if [ -f "/usr/libexec/ubuntu_init" ]; then
+    /usr/libexec/ubuntu_init
+else
+    /snap/ubuntu-core-desktop-init/current/bin/ubuntu_init
+fi
 
 EOF
 chmod 755 /usr/libexec/launch-setup.sh

--- a/hooks/010-configure-system-setup-tool.chroot
+++ b/hooks/010-configure-system-setup-tool.chroot
@@ -1,0 +1,32 @@
+#!/bin/bash -x
+
+set -e
+
+apt install zenity
+
+# Launch ubuntu-core-desktop-init instead of gnome-initial-setup
+cp /usr/share/applications/gnome-initial-setup.desktop /usr/share/applications/ubuntu-core-desktop-init.desktop
+sed -i 's#/usr/libexec/gnome-initial-setup#/usr/libexec/launch-setup.sh#g' /usr/share/applications/ubuntu-core-desktop-init.desktop
+
+sed -i 's#gnome-initial-setup#ubuntu-core-desktop-init#g' /usr/share/gnome-session/sessions/gnome-initial-setup.session
+
+cp /usr/share/polkit-1/rules.d/20-gnome-initial-setup.rules /usr/share/polkit-1/rules.d/20-ubuntu-core-desktop-init.rules
+sed -i 's#gnome-initial-setup#ubuntu-core-desktop-init#g' /usr/share/polkit-1/rules.d/20-ubuntu-core-desktop-init.rules
+
+# write the launch script
+cat > /usr/libexec/launch-setup.sh <<EOF
+#!/bin/sh
+
+# launch the configuration program
+export G_MESSAGES_DEBUG=all
+/snap/ubuntu-core-desktop-init/current/bin/ubuntu_init
+
+# Inform the user that the system will be rebooted.
+# Maybe we need a way of translating this...
+zenity --info --text="Installation complete.\nSystem will be rebooted"
+
+reboot
+
+EOF
+chmod 755 /usr/libexec/launch-setup.sh
+

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -78,14 +78,12 @@ parts:
       craftctl default
     override-prime: |
       # Do nothing
-
   splash-theme:
     plugin: dump
     source: https://github.com/snapcore/plymouth-theme-ubuntu-core.git
     source-type: git
     organize:
       ubuntu-core: usr/share/plymouth/themes/ubuntu-core
-
   bootstrap:
     after:
       - probert-deb

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -51,7 +51,17 @@ parts:
     prime:
       - -local-debs
 
+  ubuntu-core-desktop-init:
+    plugin: nil
+    override-build: |
+      snap download ubuntu-core-desktop-init
+      unsquashfs *.snap
+      mkdir -p $CRAFT_PART_INSTALL/usr/libexec
+      cp -a squashfs-root/bin/ubuntu_init $CRAFT_PART_INSTALL/usr/libexec/
+      craftctl default
+
   base:
+    after: [ubuntu-core-desktop-init]
     plugin: nil
     source: keyrings
     build-packages:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -51,17 +51,7 @@ parts:
     prime:
       - -local-debs
 
-  ubuntu-core-desktop-init:
-    plugin: nil
-    override-build: |
-      snap download ubuntu-core-desktop-init
-      unsquashfs *.snap
-      mkdir -p $CRAFT_PART_INSTALL/usr/libexec
-      cp -a squashfs-root/bin/ubuntu_init $CRAFT_PART_INSTALL/usr/libexec/
-      craftctl default
-
   base:
-    after: [ubuntu-core-desktop-init]
     plugin: nil
     source: keyrings
     build-packages:
@@ -88,12 +78,14 @@ parts:
       craftctl default
     override-prime: |
       # Do nothing
+
   splash-theme:
     plugin: dump
     source: https://github.com/snapcore/plymouth-theme-ubuntu-core.git
     source-type: git
     organize:
       ubuntu-core: usr/share/plymouth/themes/ubuntu-core
+
   bootstrap:
     after:
       - probert-deb


### PR DESCRIPTION
This PR uses ubuntu-core-desktop-init instead of gnome-session-init to configure the system.

To fully work, it requires:
- https://github.com/canonical/ubuntu-desktop-provision/pull/122
- https://github.com/canonical/ubuntu-core-desktop/pull/55
- https://github.com/canonical/ubuntu-desktop-provision/pull/144
- https://github.com/canonical/dbus.dart/pull/363
- https://github.com/canonical/ubuntu-core-desktop-init/pull/47