### PR TITLE
Add a delay when relaunching xdg-desktop-portal-*

### DIFF
--- a/hooks/006-add-gdm.chroot
+++ b/hooks/006-add-gdm.chroot
@@ -141,3 +141,7 @@ rm -f /usr/lib/systemd/user/org.gnome.Shell*
 
 # Stop "gnome-language-selector" showing in the Dash
 rm -f /usr/share/applications/gnome-language-selector.desktop
+
+# Add a delay on restart for xdg-desktop-portal-*
+sed -i "s/^ExecStart=/RestartSec=1\nExecStart=/g" /usr/lib/systemd/user/xdg-desktop-portal-gtk.service
+sed -i "s/^ExecStart=/RestartSec=1\nExecStart=/g" /usr/lib/systemd/user/xdg-desktop-portal-gnome.service


### PR DESCRIPTION
If xdg-desktop-portal-gtk or xdg-desktop-portal-gnome fail to launch, it makes no sense to relaunch it immediately; instead it's better to wait one second and only then retry.

This patch adds that delay to the systemd files.