### PR TITLE
Added alsa-ucm-conf

### DIFF
--- a/hooks/006-add-gdm.chroot
+++ b/hooks/006-add-gdm.chroot
@@ -56,7 +56,8 @@ apt install --no-install-recommends -y \
     xdg-desktop-portal-gnome \
     xdg-desktop-portal-gtk \
     xdg-user-dirs-gtk \
-    inotify-tools
+    inotify-tools \
+    alsa-ucm-conf
 
 # Remove setuid from some executables we're not using
 chmod u-s,g-s /usr/bin/pkexec


### PR DESCRIPTION
Added alsa-ucm-conf which does help on some devices.  For example, with alsa-ucm-conf the steam deck does show the audio devices in settings. It doesn't completely fix the audio issues there, but it no longer reports them as dummy devices.