### PR TITLE
Udeng 1681 core desktop bug oobe doesnt display proper background or theme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,9 @@ install:
 		mknod -m 666 $(DESTDIR)/dev/urandom c 1 9
 	# copy static files verbatim
 	/bin/cp -a static/* $(DESTDIR)
+	# generate dconf data for init
+	/usr/bin/dconf compile init-default.compiled dconf-init-data
+	/bin/mv init-default.compiled $(DESTDIR)/
 	mkdir -p $(DESTDIR)/install-data
 	/bin/cp -r $(CRAFT_STAGE)/local-debs $(DESTDIR)/install-data/local-debs
 	$(CRAFT_PROJECT_DIR)/generate-connections.py $(CRAFT_PROJECT_DIR)/snap-connections.txt $(DESTDIR)/usr/libexec/snap-connections.sh

--- a/dconf-init-data/background-defaults
+++ b/dconf-init-data/background-defaults
@@ -3,7 +3,7 @@ picture-options="zoom"
 picture-uri="file:///usr/share/backgrounds/ubuntu-core-desktop-l.png"
 picture-uri-dark="file:///usr/share/backgrounds/ubuntu-core-desktop-d.png"
 
-# original default values
+# original default values obtained from https://gitlab.gnome.org/GNOME/gnome-initial-setup
 [org/gnome/desktop/a11y]
 always-show-universal-access-status=true
 

--- a/dconf-init-data/background-defaults
+++ b/dconf-init-data/background-defaults
@@ -1,0 +1,13 @@
+[org/gnome/desktop/background]
+picture-options="zoom"
+picture-uri="file:///usr/share/backgrounds/ubuntu-core-desktop-l.png"
+picture-uri-dark="file:///usr/share/backgrounds/ubuntu-core-desktop-d.png"
+
+# original default values
+[org/gnome/desktop/a11y]
+always-show-universal-access-status=true
+
+[org/gnome/desktop/lockdown]
+disable-lock-screen=true
+disable-log-out=true
+disable-user-switching=true

--- a/hooks/010-configure-system-setup-tool.chroot
+++ b/hooks/010-configure-system-setup-tool.chroot
@@ -2,11 +2,11 @@
 
 set -e
 
-apt install --no-install-recommends -y gnome-initial-setup
+apt install --no-install-recommends -y gnome-initial-setup dconf-cli
 
 # Launch ubuntu-core-desktop-init instead of gnome-initial-setup
 mv /usr/share/applications/gnome-initial-setup.desktop /usr/share/applications/ubuntu-core-desktop-init.desktop
-sed -i 's#/usr/libexec/gnome-initial-setup#/snap/ubuntu-core-desktop-init/current/bin/ubuntu_init#g' /usr/share/applications/ubuntu-core-desktop-init.desktop
+sed -i 's#/usr/libexec/gnome-initial-setup#/usr/bin/launch_init.sh#g' /usr/share/applications/ubuntu-core-desktop-init.desktop
 
 sed -i 's#gnome-initial-setup#ubuntu-core-desktop-init#g' /usr/share/gnome-session/sessions/gnome-initial-setup.session
 
@@ -21,3 +21,20 @@ rm -f /usr/lib/systemd/user/gnome-initial-setup-first-login.service
 rm -f /etc/xdg/autostart/gnome-initial-setup-copy-worker.desktop
 rm -f /etc/xdg/autostart/gnome-initial-setup-first-login.desktop
 
+# configure the Ubuntu theme colors for the initial session
+sed -i '2 i "stylesheetName": "Yaru/gnome-shell.css",' /usr/share/gnome-shell/modes/initial-setup.json
+sed -i '3 i "colorScheme": "prefer-light",' /usr/share/gnome-shell/modes/initial-setup.json
+sed -i '4 i "themeResourceName": "theme/Yaru/gnome-shell-theme.gresource",' /usr/share/gnome-shell/modes/initial-setup.json
+sed -i '5 i "iconsResourceName": "theme/Yaru/gnome-shell-icons.gresource",' /usr/share/gnome-shell/modes/initial-setup.json
+
+cat > /usr/bin/launch_init.sh <<EOF
+#!/bin/sh
+
+/usr/bin/dconf write /org/gnome/desktop/background/picture-options \"zoom\"
+/usr/bin/dconf write /org/gnome/desktop/background/picture-uri \"file:///usr/share/backgrounds/ubuntu-core-desktop-l.png\"
+/usr/bin/dconf write /org/gnome/desktop/background/picture-uri-dark \"file:///usr/share/backgrounds/ubuntu-core-desktop-d.png\"
+
+/snap/ubuntu-core-desktop-init/current/bin/ubuntu_init
+EOF
+
+chmod 755 /usr/bin/launch_init.sh

--- a/hooks/010-configure-system-setup-tool.chroot
+++ b/hooks/010-configure-system-setup-tool.chroot
@@ -6,7 +6,7 @@ apt install --no-install-recommends -y gnome-initial-setup dconf-cli
 
 # Launch ubuntu-core-desktop-init instead of gnome-initial-setup
 mv /usr/share/applications/gnome-initial-setup.desktop /usr/share/applications/ubuntu-core-desktop-init.desktop
-sed -i 's#/usr/libexec/gnome-initial-setup#/usr/bin/launch_init.sh#g' /usr/share/applications/ubuntu-core-desktop-init.desktop
+sed -i 's#/usr/libexec/gnome-initial-setup#/snap/ubuntu-core-desktop-init/current/bin/ubuntu_init#g' /usr/share/applications/ubuntu-core-desktop-init.desktop
 
 sed -i 's#gnome-initial-setup#ubuntu-core-desktop-init#g' /usr/share/gnome-session/sessions/gnome-initial-setup.session
 
@@ -27,14 +27,4 @@ sed -i '3 i "colorScheme": "prefer-light",' /usr/share/gnome-shell/modes/initial
 sed -i '4 i "themeResourceName": "theme/Yaru/gnome-shell-theme.gresource",' /usr/share/gnome-shell/modes/initial-setup.json
 sed -i '5 i "iconsResourceName": "theme/Yaru/gnome-shell-icons.gresource",' /usr/share/gnome-shell/modes/initial-setup.json
 
-cat > /usr/bin/launch_init.sh <<EOF
-#!/bin/sh
-
-/usr/bin/dconf write /org/gnome/desktop/background/picture-options \"zoom\"
-/usr/bin/dconf write /org/gnome/desktop/background/picture-uri \"file:///usr/share/backgrounds/ubuntu-core-desktop-l.png\"
-/usr/bin/dconf write /org/gnome/desktop/background/picture-uri-dark \"file:///usr/share/backgrounds/ubuntu-core-desktop-d.png\"
-
-/snap/ubuntu-core-desktop-init/current/bin/ubuntu_init
-EOF
-
-chmod 755 /usr/bin/launch_init.sh
+mv /init-default.compiled /usr/share/gnome-initial-setup/initial-setup-dconf-defaults

--- a/hooks/010-configure-system-setup-tool.chroot
+++ b/hooks/010-configure-system-setup-tool.chroot
@@ -2,7 +2,7 @@
 
 set -e
 
-apt install --no-install-recommends -y gnome-initial-setup dconf-cli
+apt install --no-install-recommends -y gnome-initial-setup
 
 # Launch ubuntu-core-desktop-init instead of gnome-initial-setup
 mv /usr/share/applications/gnome-initial-setup.desktop /usr/share/applications/ubuntu-core-desktop-init.desktop

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -94,6 +94,7 @@ parts:
     build-packages:
       - shellcheck
       - distro-info
+      - dconf-cli
     override-pull: |
       craftctl set version="$(/bin/date +%Y%m%d)"
       craftctl default


### PR DESCRIPTION
In the first boot, the gnome shell colors are incorrect, using the default ones instead of the Yaru ones, and the background is also a blue color.

This patch fixes both bugs.