### PR TITLE
Add systemd-journal user

### DIFF
--- a/hooks/000-provide-uids-gids.chroot
+++ b/hooks/000-provide-uids-gids.chroot
@@ -125,6 +125,7 @@ gnome-initial-setup:x:114:65534::/run/gnome-initial-setup/:/bin/false
 rtkit:x:115:124:RealtimeKit,,,:/proc:/usr/sbin/nologin
 pipewire:x:116:125:Pipewire,,,:/proc:/usr/sbin/nologin
 polkitd:x:117:126:polkit:/nonexistent:/usr/sbin/nologin
+systemd-journal:x:118:106:Reserved:/run/systemd:/bin/false
 EOF
 cp /etc/passwd /etc/passwd.orig # We make a copy for a later sanity-compare
 
@@ -155,6 +156,7 @@ systemd-timesync:*:16413:0:99999:7:::
 systemd-network:*:16413:0:99999:7:::
 systemd-resolve:*:16413:0:99999:7:::
 systemd-bus-proxy:*:16413:0:99999:7:::
+systemd-journal:*:16413:0:99999:7:::
 _apt:*:16780:0:99999:7:::
 syslog:*:16521:0:99999:7:::
 dnsmasq:*:16644:0:99999:7:::


### PR DESCRIPTION
For the new systemd version it seems that this user is required. This patch adds it. But wait until the 249.11-0ubuntu3.12 version of systemd has been moved to backports.