### PR TITLE
Add provd and last ubuntu desktop init

### DIFF
--- a/generate-connections.py
+++ b/generate-connections.py
@@ -33,6 +33,7 @@ while : ; do
                 continue
             snap_name = line[:line.find(":")]
             destination_data.write(f"""
+    echo Connecting {line}
     if /usr/bin/snap list {snap_name}; then
         if ! /usr/bin/snap connect {line}; then
             retval=1

--- a/hooks/000-provide-uids-gids.chroot
+++ b/hooks/000-provide-uids-gids.chroot
@@ -126,6 +126,7 @@ rtkit:x:115:124:RealtimeKit,,,:/proc:/usr/sbin/nologin
 pipewire:x:116:125:Pipewire,,,:/proc:/usr/sbin/nologin
 polkitd:x:117:126:polkit:/nonexistent:/usr/sbin/nologin
 systemd-journal:x:118:106:Reserved:/run/systemd:/bin/false
+provd:x:119:127:Reserved:/run/provd:/bin/false
 EOF
 cp /etc/passwd /etc/passwd.orig # We make a copy for a later sanity-compare
 
@@ -217,6 +218,7 @@ messagebus:x:103:
 snappypkg:x:104:
 ssh:x:105:
 systemd-journal:x:106:
+input:x:107:
 systemd-timesync:x:108:
 systemd-network:x:109:
 systemd-resolve:x:110:
@@ -225,10 +227,9 @@ kvm:x:112:
 syslog:x:114:
 pkcs11:x:115:
 tss:x:116:
-input:x:107:
 render:x:117:
-sgx:x:119:
 _ssh:x:118:
+sgx:x:119:
 geoclue:x:120:
 gdm:x:121:
 scanner:x:122:
@@ -236,6 +237,7 @@ colord:x:123:
 rtkit:x:124:
 pipewire:x:125:
 polkitd:x:126:
+provd:x:127:gnome-initial-setup
 EOF
 cp /etc/group /etc/group.orig # We make a copy for a later sanity-compare
 
@@ -305,5 +307,6 @@ colord:!::
 pipewire:!::
 rtkit:!::
 polkitd:!*::
+provd:!::gnome-initial-setup
 EOF
 cp /etc/gshadow /etc/gshadow.orig # We make a copy for a later sanity-compare

--- a/hooks/000-provide-uids-gids.chroot
+++ b/hooks/000-provide-uids-gids.chroot
@@ -218,7 +218,6 @@ messagebus:x:103:
 snappypkg:x:104:
 ssh:x:105:
 systemd-journal:x:106:
-input:x:107:
 systemd-timesync:x:108:
 systemd-network:x:109:
 systemd-resolve:x:110:
@@ -227,9 +226,10 @@ kvm:x:112:
 syslog:x:114:
 pkcs11:x:115:
 tss:x:116:
+input:x:107:
 render:x:117:
-_ssh:x:118:
 sgx:x:119:
+_ssh:x:118:
 geoclue:x:120:
 gdm:x:121:
 scanner:x:122:

--- a/hooks/000-provide-uids-gids.chroot
+++ b/hooks/000-provide-uids-gids.chroot
@@ -126,7 +126,6 @@ rtkit:x:115:124:RealtimeKit,,,:/proc:/usr/sbin/nologin
 pipewire:x:116:125:Pipewire,,,:/proc:/usr/sbin/nologin
 polkitd:x:117:126:polkit:/nonexistent:/usr/sbin/nologin
 systemd-journal:x:118:106:Reserved:/run/systemd:/bin/false
-provd:x:119:127:Reserved:/run/provd:/bin/false
 EOF
 cp /etc/passwd /etc/passwd.orig # We make a copy for a later sanity-compare
 

--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -68,7 +68,7 @@ EOF
 cat <<EOF >/etc/apt/preferences
 Package: *
 Pin: origin ""
-Pin-Priority: 1005
+Pin-Priority: 900
 
 Package: *
 Pin: release o=LP-PPA-desktop-snappers-core-desktop
@@ -100,7 +100,7 @@ ebrtrD1Hrw3BetRY4aQ0ysRSugvbTwqS0d17zepomYJS49Jy2w2D
 EOF
 
 # enable desktop-snappers PPA
-cat << \EOF > /etc/apt/trusted.gpg.d/desktop-snappers-core-desktop.asc
+cat << EOF > /etc/apt/trusted.gpg.d/desktop-snappers-core-desktop.asc
 -----BEGIN PGP PUBLIC KEY BLOCK-----
 
 xsFNBF9y96cBEADYO8RUQ92fvHYzsJzQLzgFNHIDJcmbo/mtrhA66QaJtnplWDqm

--- a/hooks/010-configure-system-setup-tool.chroot
+++ b/hooks/010-configure-system-setup-tool.chroot
@@ -36,8 +36,6 @@ pages:
     visible: false
   ubuntu-pro-onboarding:
     visible: false
-  accessibility:
-    visible: false
 
 EOF
 

--- a/hooks/010-configure-system-setup-tool.chroot
+++ b/hooks/010-configure-system-setup-tool.chroot
@@ -22,7 +22,9 @@ mkdir -p /run/gnome-initial-setup/.cache
 until [ -S /run/gnome-initial-setup/desktop-provision/init.socket ]; do
 	sleep 1
 done
-env DBUS_SESSION_BUS_ADDRESS="unix:path=\$XDG_RUNTIME_DIR/bus" WAYLAND_DISPLAY=\$XDG_RUNTIME_DIR/wayland-0 /snap/ubuntu-desktop-init/current/bin/ubuntu_init
+
+env DBUS_SESSION_BUS_ADDRESS="unix:path=\$XDG_RUNTIME_DIR/bus" WAYLAND_DISPLAY=\$XDG_RUNTIME_DIR/wayland-0 DESKTOP_PROVISION_PATH=/usr/share/desktop-provision /snap/ubuntu-desktop-init/current/bin/ubuntu_init
+
 EOF
 
 mkdir -p /usr/share/desktop-provision
@@ -35,6 +37,8 @@ pages:
   ubuntu-pro:
     visible: false
   telemetry:
+    visible: false
+  accessibility:
     visible: false
 
 EOF

--- a/hooks/010-configure-system-setup-tool.chroot
+++ b/hooks/010-configure-system-setup-tool.chroot
@@ -36,7 +36,13 @@ pages:
     visible: false
   ubuntu-pro-onboarding:
     visible: false
-
+  accessibility:
+    # The a11y page is non-functional without sprovd. It's also not
+    # clear it placed settings in a place the ubuntu-desktop-session
+    # snap would see them.
+    visible: false
+  privacy:
+    visible: false
 EOF
 
 

--- a/hooks/010-configure-system-setup-tool.chroot
+++ b/hooks/010-configure-system-setup-tool.chroot
@@ -25,6 +25,21 @@ done
 env DBUS_SESSION_BUS_ADDRESS="unix:path=\$XDG_RUNTIME_DIR/bus" WAYLAND_DISPLAY=\$XDG_RUNTIME_DIR/wayland-0 /snap/ubuntu-desktop-init/current/bin/ubuntu_init
 EOF
 
+mkdir -p /usr/share/desktop-provision
+
+cat > /usr/share/desktop-provision/whitelabel.yaml << EOF
+mode: core-desktop
+pages:
+  eula:
+    visible: false
+  ubuntu-pro:
+    visible: false
+  telemetry:
+    visible: false
+
+EOF
+
+
 # remove unneeded files to free space
 rm -f /usr/lib/systemd/user/gnome-session.target.wants/gnome-initial-setup-copy-worker.service
 rm -f /usr/lib/systemd/user/gnome-session.target.wants/gnome-initial-setup-first-login.service

--- a/hooks/010-configure-system-setup-tool.chroot
+++ b/hooks/010-configure-system-setup-tool.chroot
@@ -22,7 +22,7 @@ mkdir -p /run/gnome-initial-setup/.cache
 until [ -S /run/gnome-initial-setup/desktop-provision/init.socket ]; do
 	sleep 1
 done
-env DBUS_SESSION_BUS_ADDRESS="unix:path=\$XDG_RUNTIME_DIR/bus" WAYLAND_DISPLAY=/run/usr/114/wayland-0 /snap/ubuntu-desktop-init/current/bin/ubuntu_init
+env DBUS_SESSION_BUS_ADDRESS="unix:path=\$XDG_RUNTIME_DIR/bus" WAYLAND_DISPLAY=\$XDG_RUNTIME_DIR/wayland-0 /snap/ubuntu-desktop-init/current/bin/ubuntu_init
 EOF
 
 # remove unneeded files to free space

--- a/hooks/010-configure-system-setup-tool.chroot
+++ b/hooks/010-configure-system-setup-tool.chroot
@@ -34,9 +34,7 @@ mode: core-desktop
 pages:
   eula:
     visible: false
-  ubuntu-pro:
-    visible: false
-  telemetry:
+  ubuntu-pro-onboarding:
     visible: false
   accessibility:
     visible: false

--- a/hooks/010-configure-system-setup-tool.chroot
+++ b/hooks/010-configure-system-setup-tool.chroot
@@ -2,13 +2,28 @@
 
 set -e
 
-apt install --no-install-recommends -y gnome-initial-setup
+apt install --no-install-recommends -y gnome-initial-setup provd
 
-# Launch ubuntu-core-desktop-init instead of gnome-initial-setup
 mv /usr/share/applications/gnome-initial-setup.desktop /usr/share/applications/ubuntu-core-desktop-init.desktop
-sed -i 's#/usr/libexec/gnome-initial-setup#/snap/ubuntu-core-desktop-init/current/bin/ubuntu_init#g' /usr/share/applications/ubuntu-core-desktop-init.desktop
+sed -i 's#/usr/libexec/gnome-initial-setup#/usr/libexec/launch-desktop-provision-init#g' /usr/share/applications/ubuntu-core-desktop-init.desktop
 
 sed -i 's#gnome-initial-setup#ubuntu-core-desktop-init#g' /usr/share/gnome-session/sessions/gnome-initial-setup.session
+
+cat > /usr/libexec/launch-desktop-provision-init << EOF
+#!/bin/sh
+
+# Create the /run/gnome-initial-setup/desktop-provision directory
+mkdir -p /run/gnome-initial-setup/desktop-provision
+
+# Create the /run/gnome-initial-setup/.cache directory
+mkdir -p /run/gnome-initial-setup/.cache
+
+/usr/libexec/provd &
+until [ -S /run/gnome-initial-setup/desktop-provision/init.socket ]; do
+	sleep 1
+done
+env DBUS_SESSION_BUS_ADDRESS="unix:path=\$XDG_RUNTIME_DIR/bus" WAYLAND_DISPLAY=/run/usr/114/wayland-0 /snap/ubuntu-desktop-init/current/bin/ubuntu_init
+EOF
 
 # remove unneeded files to free space
 rm -f /usr/lib/systemd/user/gnome-session.target.wants/gnome-initial-setup-copy-worker.service


### PR DESCRIPTION
This patch replaces the custom-modified `ubuntu-core-desktop-init` snap with the upstream `ubuntu-desktop-init` snap. It requires https://github.com/canonical/ubuntu-core-desktop/pull/73