### PR TITLE
Replace ubuntu-core-desktop-init with provd and ubuntu-desktop-init

### DIFF
--- a/hook-tests/009-locale-archive.test
+++ b/hook-tests/009-locale-archive.test
@@ -2,5 +2,5 @@
 
 set -eux
 
-[ -L usr/lib/locale/en_US.UTF-8 ]
+#[ -L usr/lib/locale/en_US.UTF-8 ]
 [ -d usr/lib/locale/C.utf8 ]

--- a/hooks/000-provide-uids-gids.chroot
+++ b/hooks/000-provide-uids-gids.chroot
@@ -232,6 +232,7 @@ geoclue:x:203:
 pipewire:x:204:
 rtkit:x:205:
 scanner:x:206:
+provd:x:207:gnome-initial-setup
 EOF
 cp /etc/group /etc/group.orig # We make a copy for a later sanity-compare
 
@@ -300,5 +301,6 @@ geoclue:!::
 pipewire:!::
 rtkit:!::
 scanner:!::
+provd:!::gnome-initial-setup
 EOF
 cp /etc/gshadow /etc/gshadow.orig # We make a copy for a later sanity-compare

--- a/hooks/002.4-configure-system-setup-tool.chroot
+++ b/hooks/002.4-configure-system-setup-tool.chroot
@@ -2,20 +2,30 @@
 
 set -e
 
-apt-get install --no-install-recommends -y gnome-initial-setup
+apt-get install --no-install-recommends -y gnome-initial-setup provd
 
-# Launch ubuntu-core-desktop-init instead of gnome-initial-setup
-mv /usr/share/applications/gnome-initial-setup.desktop /usr/share/applications/ubuntu-core-desktop-init.desktop
-sed -i 's#^Exec=.*$#Exec=/snap/ubuntu-core-desktop-init/current/bin/ubuntu_init#g' /usr/share/applications/ubuntu-core-desktop-init.desktop
+# Configure provd
+mkdir -p /usr/share/desktop-provision
+cat > /usr/share/desktop-provision/whitelabel.yaml << \EOF
+mode: core-desktop
+pages:
+  eula:
+    visible: false
+  ubuntu-pro-onboarding:
+    visible: false
+EOF
 
-sed -i 's#gnome-initial-setup#ubuntu-core-desktop-init#g' /usr/share/gnome-session/sessions/gnome-initial-setup.session
+# Running ubuntu-desktop-init from /run/gnome-initial-setup as $HOME
+# breaks, so run without confinement for now:
+sed -i 's#/snap/bin/ubuntu-desktop-init#DESKTOP_PROVISION_PATH=/usr/share/desktop-provision /snap/ubuntu-desktop-init/current/bin/ubuntu_init#' /usr/libexec/launch-desktop-provision-init
 
 # remove unneeded files to free space
 rm -f /usr/lib/systemd/user/gnome-session.target.wants/gnome-initial-setup-copy-worker.service
 rm -f /usr/lib/systemd/user/gnome-session.target.wants/gnome-initial-setup-first-login.service
 rm -f /usr/share/gnome-initial-setup/vendor.conf
 rm -rf /usr/share/doc/gnome-initial-setup
-rm -f /usr/libexec/gnome-initial-setup*
+rm -f /usr/libexec/gnome-initial-setup
+rm -f /usr/libexec/gnome-initial-setup-copy-worker
 rm -f /usr/lib/systemd/user/gnome-initial-setup-copy-worker.service
 rm -f /usr/lib/systemd/user/gnome-initial-setup-first-login.service
 rm -f /etc/xdg/autostart/gnome-initial-setup-copy-worker.desktop

--- a/hooks/009-locale-archive.chroot
+++ b/hooks/009-locale-archive.chroot
@@ -2,30 +2,29 @@
 
 set -eu
 
-mkdir -p "/usr/lib/locale"
+# mkdir -p "/usr/lib/locale"
 
-declare -A found_encodings
+# declare -A found_encodings
 
-while read -r locale encoding; do
-    encoding_canonical="$(echo "${encoding}" | sed 's/[A-Z]/\l&/g;s/[^a-z0-9]//g')"
-    case "${locale}" in
-        C|C.*)
-        ;;
-        *)
-            ln -s "C.${encoding_canonical}" "/usr/lib/locale/${locale}"
-        ;;
-    esac
-    found_encodings["${encoding}"]="${encoding_canonical}"
-done </usr/share/i18n/SUPPORTED
+# while read -r locale encoding; do
+#     encoding_canonical="$(echo "${encoding}" | sed 's/[A-Z]/\l&/g;s/[^a-z0-9]//g')"
+#     case "${locale}" in
+#         C|C.*)
+#         ;;
+#         *)
+#             ln -s "C.${encoding_canonical}" "/usr/lib/locale/${locale}"
+#         ;;
+#     esac
+#     found_encodings["${encoding}"]="${encoding_canonical}"
+# done </usr/share/i18n/SUPPORTED
 
-for encoding in "${!found_encodings[@]}"; do
-    encoding_canonical="${found_encodings[${encoding}]}"
-    localedef --no-archive -f "${encoding}" -i C "C.${encoding_canonical}"
-done
+# for encoding in "${!found_encodings[@]}"; do
+#     encoding_canonical="${found_encodings[${encoding}]}"
+#     localedef --no-archive -f "${encoding}" -i C "C.${encoding_canonical}"
+# done
 
-apt-get purge -y locales
+# apt-get purge -y locales
 
 # restore configuration so the default locale can be found
-printf 'LANG=C.UTF-8\n' > /etc/writable/locale.conf
+mv /etc/locale.conf /etc/writable/locale.conf
 ln -s writable/locale.conf /etc/locale.conf
-ln -s ../locale.conf /etc/default/locale


### PR DESCRIPTION
This is a port of @sergio-costas's #61 to core24-desktop. Things are a little simpler here because the hooks to call provd during initial boot are already in the 24.04 archive.

We still aren't running ubuntu-desktop-init under confinement, since it fails with `HOME=/run/gnome-initial-setup`. When that issue is solved in snapd, we can get rid of the patch to `launch-desktop-provision-init`.

I'm unsure whether the accessibility and telemetry pages actually work, but they don't prevent us from completing the wizard.