### PR TITLE
Add missing 'export DEBIAN_FRONTEND'

### DIFF
--- a/hooks/002-add-locales.chroot
+++ b/hooks/002-add-locales.chroot
@@ -7,6 +7,8 @@ set -e
 ORIG_BASE_DIR="/usr/share/locale-langpack"
 DEST_BASE_DIR="/usr/share/locale"
 
+export DEBIAN_FRONTEND=noninteractive
+
 apt install -y '^language-pack-gnome-[a-z]+-base$'
 
 for PATH in "$ORIG_BASE_DIR"/*; do

--- a/hooks/012-add-foreign-libc6.chroot
+++ b/hooks/012-add-foreign-libc6.chroot
@@ -2,6 +2,8 @@
 
 echo "I: Checking if we are amd64 and libc6:i386 should be installed"
 
+export DEBIAN_FRONTEND=noninteractive
+
 if [ "$(dpkg --print-architecture)" = "amd64" ]; then
     echo "I: Enabling i386 multiarch support on amd64"
     dpkg --add-architecture i386

--- a/hooks/600-no-debian.chroot
+++ b/hooks/600-no-debian.chroot
@@ -4,6 +4,8 @@
 
 set -ex
 
+export DEBIAN_FRONTEND=noninteractive
+
 echo "I: Removing the debian legacy"
 
 # store manifest of all installed packages


### PR DESCRIPTION
Using APT requires to set DEBIAN_FRONTEND to noninteractive, to ensure that it works unatended. Unfortunately, some scripts missed it.

This patch fixes it.