### PR TITLE
Add provd user

### DIFF
--- a/hooks/000-provide-uids-gids.chroot
+++ b/hooks/000-provide-uids-gids.chroot
@@ -126,6 +126,7 @@ rtkit:x:115:124:RealtimeKit,,,:/proc:/usr/sbin/nologin
 pipewire:x:116:125:Pipewire,,,:/proc:/usr/sbin/nologin
 polkitd:x:117:126:polkit:/nonexistent:/usr/sbin/nologin
 systemd-journal:x:118:106:Reserved:/run/systemd:/bin/false
+provd:x:119:127:Reserved:/run/provd:/bin/false
 EOF
 cp /etc/passwd /etc/passwd.orig # We make a copy for a later sanity-compare
 


### PR DESCRIPTION
This is required to avoid build failure

:: Preparing to unpack .../provd_0.1.5~ppa2_amd64.deb ...
:: Unpacking provd (0.1.5~ppa2) ...
:: Setting up provd (0.1.5~ppa2) ...
:: Adding system user `provd' (UID 107) ...
:: Adding new user `provd' (UID 107) with group `nogroup' ...
:: usermod: user 'provd' does not exist
:: adduser.real: `/sbin/usermod -p * provd' returned error code 6. Exiting.
:: dpkg: error processing package provd (--configure):
::  installed provd package post-installation script subprocess returned error exit status 1
:: Processing triggers for gnome-menus (3.36.0-1ubuntu3) ...
:: Processing triggers for libc-bin (2.35-0ubuntu3.8) ...
:: Processing triggers for desktop-file-utils (0.26-1ubuntu3) ...
:: Errors were encountered while processing:
::  provd