### PR TITLE
Adapt to snapped pipewire

### DIFF
--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -176,6 +176,7 @@ apt-get update
 apt-get dist-upgrade -y --allow-downgrades
 
 PACKAGES=(
+    alsa-utils
     apparmor
     bash-completion
     bzip2

--- a/hooks/002.1-add-gdm.chroot
+++ b/hooks/002.1-add-gdm.chroot
@@ -22,9 +22,6 @@ apt-get install --no-install-recommends -y \
     fonts-ubuntu \
     ubuntu-settings \
     xdg-user-dirs \
-    pipewire \
-    wireplumber \
-    pipewire-pulse \
     pulseaudio-utils \
     libgsound0 \
     gsound-tools \

--- a/hooks/002.1-add-gdm.chroot
+++ b/hooks/002.1-add-gdm.chroot
@@ -84,8 +84,6 @@ rm -f /usr/share/dbus-1/services/org.gnome.evolution.dataserver.*
 
 # Remove systemd activation in services managed by
 # ubuntu-desktop-session snap
-rm -f /usr/lib/systemd/user/pipewire*
-rm -f /usr/lib/systemd/user/wireplumber*
 rm -rf /etc/systemd/user/pipewire*
 rm -f /etc/systemd/user/sockets.target.wants/pipewire*
 rm -f /etc/systemd/user/default.target.wants/pipewire*

--- a/static/usr/bin/core-desktop-session-wrapper.sh
+++ b/static/usr/bin/core-desktop-session-wrapper.sh
@@ -36,5 +36,8 @@ fixup_xauthority &
 
 # Symlink the Wayland socket from the snap's private directory
 ln -sf "snap.$snap_name/wayland-0" $XDG_RUNTIME_DIR/wayland-0
+# Symlink sockets for pipewire and pipewire-pulse
+ln -sf "snap.$snap_name/pipewire-0" $XDG_RUNTIME_DIR/pipewire-0
+ln -sf "snap.$snap_name/pulse" $XDG_RUNTIME_DIR/pulse
 
 exec "/snap/bin/$snap_cmd"

--- a/static/usr/bin/core-desktop-session-wrapper.sh
+++ b/static/usr/bin/core-desktop-session-wrapper.sh
@@ -36,8 +36,5 @@ fixup_xauthority &
 
 # Symlink the Wayland socket from the snap's private directory
 ln -sf "snap.$snap_name/wayland-0" $XDG_RUNTIME_DIR/wayland-0
-# Symlink sockets for pipewire and pipewire-pulse
-ln -sf "snap.$snap_name/pipewire-0" $XDG_RUNTIME_DIR/pipewire-0
-ln -sf "snap.$snap_name/pulse" $XDG_RUNTIME_DIR/pulse
 
 exec "/snap/bin/$snap_cmd"

--- a/static/usr/bin/core-desktop-session-wrapper.sh
+++ b/static/usr/bin/core-desktop-session-wrapper.sh
@@ -37,7 +37,7 @@ fixup_xauthority &
 # Symlink the Wayland socket from the snap's private directory
 ln -sf "snap.$snap_name/wayland-0" $XDG_RUNTIME_DIR/wayland-0
 # Symlink sockets for pipewire and pipewire-pulse
-ln -sf "snap.$snap_name/pipewire-0" $XDG_RUNTIME_DIR/pipewire-0
-ln -sf "snap.$snap_name/pulse" $XDG_RUNTIME_DIR/pulse
+ln -sf "snap.pipewire/pipewire-0" $XDG_RUNTIME_DIR/pipewire-0
+ln -sf "snap.pipewire/pulse" $XDG_RUNTIME_DIR/pulse
 
 exec "/snap/bin/$snap_cmd"


### PR DESCRIPTION
This PR removes pipewire and leaves it ready to use the snapped version.