### PR TITLE
Remove pipewire to use pipewire-snap

### DIFF
--- a/hooks/599-cleanup-packages.chroot
+++ b/hooks/599-cleanup-packages.chroot
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -e
+echo Removing pipewire
+# remove packages that were installed due to dependencies but that we
+# must remove.
+dpkg -r --force-all pipewire pipewire-bin wireplumber pipewire-pulse libspa-0.2-modules libpipewire-0.3-modules


### PR DESCRIPTION
Pipewire, wireplumber and pipewire-pulse should be removed.