### PR TITLE
Fix build

### DIFF
--- a/tools/generate-changelog.py
+++ b/tools/generate-changelog.py
@@ -69,7 +69,7 @@ def get_changelog_from_file(docs_d, pkg):
         with gzip.open(chl_deb_path) as chl_fh:
             return chl_fh.read().decode('utf-8')
     elif os.path.exists(chl_path):
-        with gzip.open(chl_deb_path) as chl_fh:
+        with gzip.open(chl_path) as chl_fh:
             return chl_fh.read().decode('utf-8')
     else:
         raise FileNotFoundError("no supported changelog found for package " + pkg)


### PR DESCRIPTION
When it checks for changelog, and changelog.Debian.gz doesn't exists, it tries to open the wrong file.