### PR TITLE
Add only gdm code not gnome shell

### DIFF
--- a/hooks/002.1-add-gdm.chroot
+++ b/hooks/002.1-add-gdm.chroot
@@ -28,33 +28,9 @@ apt-get install --no-install-recommends -y \
     gir1.2-gsound-1.0 \
     libcanberra-pulse \
     libsnapd-glib-2-1 \
-    ibus
-
-# Install a basic Ubuntu session
-apt-get install --no-install-recommends -y \
-    ubuntu-session \
-    gkbd-capplet \
-    gnome-menus \
-    gnome-terminal \
-    gnome-settings-daemon \
-    gnome-shell-extension-appindicator \
-    gnome-shell-extension-desktop-icons-ng \
-    gnome-shell-extension-ubuntu-dock \
-    gnome-shell-extension-ubuntu-tiling-assistant \
-    gnome-control-center \
-    gnome-keyring \
-    fprintd \
-    libpam-fprintd \
-    opensc \
-    bolt \
-    libpam-gnome-keyring \
-    spice-vdagent \
-    xdg-desktop-portal \
-    xdg-desktop-portal-gnome \
-    xdg-desktop-portal-gtk \
-    xdg-user-dirs-gtk \
-    inotify-tools \
-    alsa-ucm-conf
+    ibus \
+    pkexec \
+    xdg-desktop-portal
 
 # Remove setuid from some executables we're not using
 chmod u-s,g-s /usr/bin/pkexec
@@ -70,11 +46,11 @@ sed -i '/^Description=/ a # delay until snapd finishes seeding\nAfter=snapd.seed
 
 # Remove D-Bus service activation files provided by
 # ubuntu-desktop-session snap.
-rm /usr/share/dbus-1/services/org.gnome.Nautilus.service
-rm /usr/share/dbus-1/services/org.gnome.Terminal.service
-rm /usr/share/dbus-1/services/org.freedesktop.impl.portal.desktop.gnome.service
-rm /usr/share/dbus-1/services/org.freedesktop.impl.portal.desktop.gtk.service
-rm /usr/share/dbus-1/services/org.gnome.Shell.Screencast.service
+rm -f /usr/share/dbus-1/services/org.gnome.Nautilus.service
+rm -f /usr/share/dbus-1/services/org.gnome.Terminal.service
+rm -f /usr/share/dbus-1/services/org.freedesktop.impl.portal.desktop.gnome.service
+rm -f /usr/share/dbus-1/services/org.freedesktop.impl.portal.desktop.gtk.service
+rm -f /usr/share/dbus-1/services/org.gnome.Shell.Screencast.service
 rm -f /usr/share/dbus-1/services/org.freedesktop.IBus.service
 rm -f /usr/share/dbus-1/services/org.freedesktop.portal.IBus.service
 rm -f /usr/share/dbus-1/services/org.freedesktop.ColorHelper.service
@@ -120,7 +96,7 @@ sed -i "/^ReadWritePaths=/ a \\  /var/lib/extrausers/ \\\\" \
     /usr/lib/systemd/system/accounts-daemon.service
 
 # Hide gnome-terminal by default
-sed -i 's/OnlyShowIn=/NoDisplay=true\nOnlyShowIn=/g' /usr/share/applications/org.gnome.Terminal.desktop
+#sed -i 's/OnlyShowIn=/NoDisplay=true\nOnlyShowIn=/g' /usr/share/applications/org.gnome.Terminal.desktop
 
 # change default wallpapers
 cp /usr/share/gnome-background-properties/ubuntu-wallpapers.xml /usr/share/gnome-background-properties/ubuntu-core-desktop-wallpapers.xml

--- a/hooks/002.1-add-gdm.chroot
+++ b/hooks/002.1-add-gdm.chroot
@@ -29,11 +29,7 @@ apt-get install --no-install-recommends -y \
     libcanberra-pulse \
     libsnapd-glib-2-1 \
     ibus \
-    pkexec \
     xdg-desktop-portal
-
-# Remove setuid from some executables we're not using
-chmod u-s,g-s /usr/bin/pkexec
 
 # Remove Ubuntu X11 session
 rm /usr/share/xsessions/ubuntu.desktop

--- a/hooks/599-cleanup-packages.chroot
+++ b/hooks/599-cleanup-packages.chroot
@@ -1,13 +1,22 @@
 #!/bin/sh
 
 set -e
-echo Removing pipewire
 # remove packages that were installed due to dependencies but that we
 # must remove.
-dpkg -r --force-all pipewire wireplumber pipewire-pulse
+echo Removing pipewire
+dpkg -r --force-all pipewire wireplumber pipewire-pulse pipewire-alsa
 
 # For pipewire-bin remove all the binaries but retain all the config from /usr/share which will
 # be used by clients and modules
 for i in $(dpkg -L pipewire-bin | grep -v "^/\.$" | grep -v "usr/share" | sed -E -e 's,^/,,' | tac) ; do
     rm -df "$i" || /bin/true
 done
+echo Removing xdg-desktop-portal-XXX
+# Save the portal file
+cp /usr/share/xdg-desktop-portal/portals/gnome.portal /usr/share/xdg-desktop-portal/portals/gnome.portal.preserve
+dpkg -r --force-all xdg-desktop-portal-gtk xdg-desktop-portal-gnome
+# Now, restore the portal file
+mv /usr/share/xdg-desktop-portal/portals/gnome.portal.preserve /usr/share/xdg-desktop-portal/portals/gnome.portal
+
+# Remove all the gnome services to ensure that they don't interfere with the ones in the session snap
+rm -f /usr/share/dbus-1/services/org.gnome.*

--- a/static/etc/system-image/writable-paths
+++ b/static/etc/system-image/writable-paths
@@ -73,7 +73,6 @@
 /etc/polkit-1/rules.d                   auto                    persistent  none        none
 /var/lib/AccountsService                auto                    persistent  transition  none
 /var/lib/gdm3                           auto                    persistent  transition  none
-/usr/share/wayland-sessions             auto                    persistent  transition  none
 /usr/share/polkit-1                     auto                    persistent  transition  none
 /var/lib/colord                         auto                    persistent  transition  none
 /var/lib/fprint                         auto                    persistent  transition  none

--- a/static/usr/bin/core-desktop-session-wrapper.sh
+++ b/static/usr/bin/core-desktop-session-wrapper.sh
@@ -61,6 +61,7 @@ fixup_xauthority &
 ln -sf "snap.$snap_name/wayland-0" $XDG_RUNTIME_DIR/wayland-0
 # Symlink sockets for pipewire and pipewire-pulse
 ln -sf "snap.pipewire/pipewire-0" $XDG_RUNTIME_DIR/pipewire-0
-ln -sf "snap.pipewire/pulse" $XDG_RUNTIME_DIR/pulse
+mkdir -p $XDG_RUNTIME_DIR/pulse
+ln -sf "../snap.pipewire/pulse/native" $XDG_RUNTIME_DIR/pulse/native
 
 exec "/snap/bin/$snap_cmd"

--- a/static/usr/bin/core-desktop-session-wrapper.sh
+++ b/static/usr/bin/core-desktop-session-wrapper.sh
@@ -61,7 +61,6 @@ fixup_xauthority &
 ln -sf "snap.$snap_name/wayland-0" $XDG_RUNTIME_DIR/wayland-0
 # Symlink sockets for pipewire and pipewire-pulse
 ln -sf "snap.pipewire/pipewire-0" $XDG_RUNTIME_DIR/pipewire-0
-mkdir -p $XDG_RUNTIME_DIR/pulse
-ln -sf "../snap.pipewire/pulse/native" $XDG_RUNTIME_DIR/pulse/native
+ln -sf "snap.pipewire/pulse" $XDG_RUNTIME_DIR/pulse
 
 exec "/snap/bin/$snap_cmd"

--- a/static/usr/share/xdg-desktop-portal/portals/gnome-keyring.portal
+++ b/static/usr/share/xdg-desktop-portal/portals/gnome-keyring.portal
@@ -1,0 +1,4 @@
+[portal]
+DBusName=org.freedesktop.secrets
+Interfaces=org.freedesktop.impl.portal.Secret
+UseIn=gnome

--- a/static/usr/share/xdg-desktop-portal/portals/kwallet.portal
+++ b/static/usr/share/xdg-desktop-portal/portals/kwallet.portal
@@ -1,0 +1,4 @@
+[portal]
+DBusName=org.freedesktop.impl.portal.desktop.kwallet
+Interfaces=org.freedesktop.impl.portal.Secret;
+UseIn=kde


### PR DESCRIPTION
Changes to remove gnome shell itself, delegating it to ubuntu-desktop-session snap. The idea is to use it along with https://github.com/canonical/ubuntu-desktop-session-snap/pull/39