### PR TITLE
/var/log might contain subdir, don't fail in that case

### DIFF
--- a/hooks/900-cleanup-etc-var.chroot
+++ b/hooks/900-cleanup-etc-var.chroot
@@ -68,7 +68,7 @@ rmdir /var/log/private
 rm -rf /var/log/gdm3
 
 # clean leftovers from the build
-rm /var/log/*
+rm -rf /var/log/*
 
 # Re-enable journal
 mkdir /var/log/journal


### PR DESCRIPTION
I had build failures due to this, it feels safer to be a bit more aggressive for this cleanup anyway.