### PR TITLE
Remove pipewire and wireplumber service files to prevent their start

### DIFF
--- a/hooks/002.1-add-gdm.chroot
+++ b/hooks/002.1-add-gdm.chroot
@@ -84,6 +84,8 @@ rm -f /usr/share/dbus-1/services/org.gnome.evolution.dataserver.*
 
 # Remove systemd activation in services managed by
 # ubuntu-desktop-session snap
+rm -f /usr/lib/systemd/user/pipewire*
+rm -f /usr/lib/systemd/user/wireplumber*
 rm -rf /etc/systemd/user/pipewire*
 rm -f /etc/systemd/user/sockets.target.wants/pipewire*
 rm -f /etc/systemd/user/default.target.wants/pipewire*


### PR DESCRIPTION
Turns out the packages are still brought as dependencies to some other package even though they are not requested explicitly anymore. So nuke their service files to avoid them being started unconfined.