### PR TITLE
Set the right home URL for Ubuntu Core distro

### DIFF
--- a/hooks/018-set-os-release.chroot
+++ b/hooks/018-set-os-release.chroot
@@ -8,6 +8,6 @@ PRETTY_NAME="Ubuntu Core 24"
 VERSION_ID="24"
 VARIANT_ID=desktop
 VARIANT="Desktop"
-HOME_URL="https://snapcraft.io/"
+HOME_URL="https://www.ubuntu.com/core"
 BUG_REPORT_URL="https://bugs.launchpad.net/snappy/"
 EOF


### PR DESCRIPTION
Otherwise applications using this variable might lead users to snapcraft instead of Ubuntu Core when they are looking for distro information.