### PR TITLE
Add plasma desktop session support

### DIFF
--- a/static/usr/bin/core-desktop-session-wrapper.sh
+++ b/static/usr/bin/core-desktop-session-wrapper.sh
@@ -5,18 +5,20 @@
 snap_cmd="$1"
 snap_name="$(echo "$snap_cmd" | cut -d . -f 1)"
 
+session_type=$2
+
 # Set up PATH and XDG_DATA_DIRS to allow calling snaps
 if [ -f /snap/snapd/current/etc/profile.d/apps-bin-path.sh ]; then
     source /snap/snapd/current/etc/profile.d/apps-bin-path.sh
 fi
 
-export XDG_CURRENT_DESKTOP=ubuntu:GNOME
+export XDG_CURRENT_DESKTOP=$session_type
 export GSETTINGS_BACKEND=keyfile
 
 dbus-update-activation-environment --systemd --all
 
 # Don't set this in our own environment, since it will make
-# gnome-session believe it is running in X mode
+# the session believe it is running in X mode
 dbus-update-activation-environment --systemd DISPLAY=:0 WAYLAND_DISPLAY=wayland-0 XAUTHORITY=$XDG_RUNTIME_DIR/.Xauthority
 
 # Set up a background task to wait for gnome-session to create its

--- a/static/usr/bin/core-desktop-session-wrapper.sh
+++ b/static/usr/bin/core-desktop-session-wrapper.sh
@@ -27,7 +27,11 @@ dbus-update-activation-environment --systemd DISPLAY=:0 WAYLAND_DISPLAY=wayland-
 function fixup_xauthority() {
     while :; do
         sleep 1s
-        xauth_file="$(ls -1t $XDG_RUNTIME_DIR/snap.$snap_name/.mutter-Xwaylandauth.* | head -n1)"
+        if [ $session_type == "KDE" ]; then
+            xauth_file="$(ls -1t $XDG_RUNTIME_DIR/snap.$snap_name/xauth_* | head -n1)"
+        else
+            xauth_file="$(ls -1t $XDG_RUNTIME_DIR/snap.$snap_name/.mutter-Xwaylandauth.* | head -n1)"
+        fi
         if [ -f "$xauth_file" ]; then
             cp "$xauth_file" $XDG_RUNTIME_DIR/.Xauthority
             return

--- a/static/usr/bin/core-desktop-session-wrapper.sh
+++ b/static/usr/bin/core-desktop-session-wrapper.sh
@@ -38,6 +38,26 @@ function fixup_xauthority() {
         fi
     done
 }
+if [ $session_type == "KDE" ]; then
+    # Temporary workaround until we can use the pipewire snap
+    ln -sf "snap.plasma-desktop-session" $XDG_RUNTIME_DIR/snap.pipewire
+
+    # Temporary workaround until we have a better way to expose our services and targets
+    # 1. Expose our targets, services and overloads
+    rm -rf $XDG_RUNTIME_DIR/systemd/user.control
+    mkdir -p $XDG_RUNTIME_DIR/systemd
+    ln -sf /snap/plasma-core24-desktop/current/usr/lib/systemd/user $XDG_RUNTIME_DIR/systemd/user.control
+    # 2. Reload the daemon so that it picks up our changes
+    systemctl --user daemon-reload
+    # 3. Stop anything now masked which might have been already started
+    masked_units=`systemctl --user show --property=Id --value --state=masked`
+    for unit in $masked_units ; do
+      systemctl --user stop $unit
+    done
+    # 4. Stop the xdg-desktop-portal in case it was started before the override was set
+    systemctl --user stop xdg-desktop-portal
+fi
+
 fixup_xauthority &
 
 # Symlink the Wayland socket from the snap's private directory

--- a/static/usr/share/wayland-sessions/plasma-desktop-session.desktop
+++ b/static/usr/share/wayland-sessions/plasma-desktop-session.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Name=Plasma (confined)
+Comment=This session logs you into KDE Plasma
+Exec=core-desktop-session-wrapper.sh plasma-desktop-session KDE
+TryExec=/snap/bin/plasma-desktop-session
+Type=Application
+DesktopNames=KDE
+X-GDM-SessionRegisters=true

--- a/static/usr/share/wayland-sessions/ubuntu-desktop-session.desktop
+++ b/static/usr/share/wayland-sessions/ubuntu-desktop-session.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Ubuntu (confined)
 Comment=This session logs you into Ubuntu
-Exec=core-desktop-session-wrapper.sh ubuntu-desktop-session
+Exec=core-desktop-session-wrapper.sh ubuntu-desktop-session ubuntu:GNOME
 TryExec=/snap/bin/ubuntu-desktop-session
 Type=Application
 DesktopNames=ubuntu:GNOME


### PR DESCRIPTION
This PR does three interrelated things:
* provides a way to start the plasma-desktop-session from GDM
* properly exposes the pipewire manager socket which was not in the runtime dir
* adds temporary workarounds specific to the plasma-desktop-session
  * one related to pipewire as its shipped by the session until the new pipewire snap package gets out of review on the store
  * one related to the lack of mechanism for exposing our own service aliases and targets to systemd to start the session
