### PR TITLE
Keep PipeWire parts necessary for clients

### DIFF
--- a/hooks/599-cleanup-packages.chroot
+++ b/hooks/599-cleanup-packages.chroot
@@ -4,4 +4,10 @@ set -e
 echo Removing pipewire
 # remove packages that were installed due to dependencies but that we
 # must remove.
-dpkg -r --force-all pipewire pipewire-bin wireplumber pipewire-pulse libspa-0.2-modules libpipewire-0.3-modules
+dpkg -r --force-all pipewire wireplumber pipewire-pulse
+
+# For pipewire-bin remove all the binaries but retain all the config from /usr/share which will
+# be used by clients and modules
+for i in $(dpkg -L pipewire-bin | grep -v "^/\.$" | grep -v "usr/share" | sed -E -e 's,^/,,' | tac) ; do
+    rm -df "$i" || /bin/true
+done


### PR DESCRIPTION
One said client is the xdg-desktop-portal. It cannot do its job for screensharing if the config in /usr/share or the spa and pipewire modules are missing. Adjusting the package cleanup to put them back into place.