### PR TITLE
Remove workaround now that Pipewire is out of the KDE session snap

### DIFF
--- a/static/usr/bin/core-desktop-session-wrapper.sh
+++ b/static/usr/bin/core-desktop-session-wrapper.sh
@@ -39,9 +39,6 @@ function fixup_xauthority() {
     done
 }
 if [ $session_type == "KDE" ]; then
-    # Temporary workaround until we can use the pipewire snap
-    ln -sf "snap.plasma-desktop-session" $XDG_RUNTIME_DIR/snap.pipewire
-
     # Temporary workaround until we have a better way to expose our services and targets
     # 1. Expose our targets, services and overloads
     rm -rf $XDG_RUNTIME_DIR/systemd/user.control


### PR DESCRIPTION
We introduced an extra symlink as the KDE session was using its own Pipewire copy. We're now depending on the Pipewire snap so it should be removed.